### PR TITLE
user_acl_rest is not initialized when it detects EC 11.0.1 or higher

### DIFF
--- a/lib/chef/knife/ec_backup.rb
+++ b/lib/chef/knife/ec_backup.rb
@@ -107,6 +107,8 @@ class Chef
                 config[:skip_useracl] = true
                 user_acl_rest = nil
               end
+            else
+              user_acl_rest = rest
             end
 
           else

--- a/lib/chef/knife/ec_restore.rb
+++ b/lib/chef/knife/ec_restore.rb
@@ -106,7 +106,10 @@ class Chef
             if server_version_parts[0].to_i < 11 || (server_version_parts[0].to_i == 11 && server_version_parts[1].to_i == 0)
               ui.warn("Your version of Enterprise Chef Server does not support the updating of User ACLs.  Setting skip-useracl to TRUE")
               config[:skip_useracl] = true
-            end
+              user_acl_rest = nil
+            else
+              user_acl_rest = rest 
+            end             
           else
             ui.warn("Unable to detect Chef Server version.")
           end


### PR DESCRIPTION
If Server 11.0.1 is detected and they do not skip user acls, user_acl_rest isn't initialized.
