### PR TITLE
Ensure users are added to admins and billing-admins group.

### DIFF
--- a/lib/chef/knife/ec_restore.rb
+++ b/lib/chef/knife/ec_restore.rb
@@ -279,7 +279,7 @@ class Chef
           Chef::Config[:client_key] = old_config['client_key'] 
           Chef::Config.custom_http_headers = {}
           ['admins', 'billing-admins'].each do |group|
-            restore_group(::ChefFS::Config.new, group, :users => false)
+            restore_group(::ChefFS::Config.new, group)
           end
          ensure
           CONFIG_VARS.each do |key|


### PR DESCRIPTION
Since the API only accepts whole documents, you have to post both the
users and the clients in the final update even though users are
already in the group.
