### PR TITLE
Install on Enterprise Chef 11

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -22,5 +22,3 @@ end
 # If you want to load debugging tools into the bundle exec sandbox,
 # # add these additional dependencies into Gemfile.local
 eval(IO.read(__FILE__ + '.local'), binding) if File.exists?(__FILE__ + '.local')
-$:.unshift(File.dirname(__FILE__) + '/lib')
-

--- a/Gemfile
+++ b/Gemfile
@@ -2,6 +2,13 @@ source :rubygems
 
 gemspec
 
+group :development do
+  gem 'rspec'
+  gem 'rake'
+  gem 'simplecov'
+  gem 'fakefs'
+end
+
 # This is here instead of gemspec so that we can
 # override which Chef gem to use when we do testing
 # Possibilities in the future include using environmental
@@ -15,3 +22,5 @@ gemspec
 # If you want to load debugging tools into the bundle exec sandbox,
 # # add these additional dependencies into Gemfile.local
 eval(IO.read(__FILE__ + '.local'), binding) if File.exists?(__FILE__ + '.local')
+$:.unshift(File.dirname(__FILE__) + '/lib')
+

--- a/README.md
+++ b/README.md
@@ -40,7 +40,7 @@ downloading the .zip file. Once unpacked, run:
 
 ```
 /opt/opscode/embedded/bin/gem build knife-ec-backup.gemspec
-/opt/opscode/embedded/bin/gem install knife-ec-backup*gem
+/opt/opscode/embedded/bin/gem install knife-ec-backup*gem --no-ri --no-rdoc -V
 ```
 
 ### Note on installing with existing development tools:
@@ -88,6 +88,8 @@ The following options are supported across all subcommands:
     The password for the sql_user.  (default: autoconfigured from /etc/opscode/chef-server-running.json)
 
 ## knife ec backup DEST_DIR (options)
+
+*Path*: If you have chef-client installed as well, you may need to invoke this as `/opt/opscode/embedded/bin/knife ec backup backup`
 
 *Options*
 

--- a/README.md
+++ b/README.md
@@ -31,9 +31,19 @@ the key data.
 # Installation
 
 ## Chef Server Install (Recommended)
-This will install the plugin directly on the Chef Server:
 
-    /opt/opscode/embedded/bin/gem install knife-ec-backup
+This gem is installed with chef-server-core 12.0.0 and newer. 
+
+For Private Chef 11 (or Enterprise Chef 11) you'll need to download and build
+locally to get the correct dependencies, either with `git clone` or by
+downloading the .zip file. Once unpacked, run:
+
+```
+/opt/opscode/embedded/bin/gem build knife-ec-backup.gemspec
+/opt/opscode/embedded/bin/gem install knife-ec-backup*gem
+```
+
+### Note on installing with existing development tools:
 
 The latest versions of knife-ec-backup require gems with native
 extensions, thus you must install a standard build toolchain.  To
@@ -43,10 +53,11 @@ on your system, try the following:
    /opt/opscode/embedded/bin/gem install knife-ec-backup -- --with-pg-config=/opt/opscode/embedded/postgresql/9.2/bin/pg_config
 
 ## Build from source
+
 Clone the git repository and run the following from inside:
 
     gem build knife-ec-backup.gemspec
-    gem install knife-ec-backup-1.1.3.gem
+    gem install knife-ec-backup*gem
 
 # Configuration
 

--- a/knife-ec-backup.gemspec
+++ b/knife-ec-backup.gemspec
@@ -20,10 +20,10 @@ Gem::Specification.new do |s|
   s.add_dependency "sequel"
   s.add_dependency "pg"
   s.add_dependency "chef", ">= 11.8"
-  s.add_development_dependency 'rspec'
-  s.add_development_dependency 'rake'
-  s.add_development_dependency 'simplecov'
-  s.add_development_dependency 'fakefs'
+
+  if RUBY_VERSION.index('1.9') == 0 then
+    s.add_dependency "ohai", "< 8.0"
+  end
 
   s.require_path = 'lib'
   s.files = %w(LICENSE README.md Rakefile) + Dir.glob("{lib,spec}/**/*")


### PR DESCRIPTION
See #56.  The ruby 1.9 version check 'should' be safe in most build environments and only add the ohai <8.0 dependency on older boxes.

I moved the development dependencies to Gemfile since gem 1.8 doesn't have the --without option.

