### PR TITLE
Updated rests in ec_base to use API V0.

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,6 +52,21 @@ on your system, try the following:
 
    /opt/opscode/embedded/bin/gem install knife-ec-backup -- --with-pg-config=/opt/opscode/embedded/postgresql/9.2/bin/pg_config
 
+## Running tests
+
+```
+$ bundle install
+$ bundle exec rspec spec/
+```
+
+If bundle install fails on the pg gem and the note above does not work for you, try:
+
+```
+$ brew install postgres (if not present)
+$ ARCHFLAGS="-arch x86_64" gem install pg
+$ bundle exec rspec spec/
+```
+
 ## Build from source
 
 Clone the git repository and run the following from inside:

--- a/lib/chef/knife/ec_backup.rb
+++ b/lib/chef/knife/ec_backup.rb
@@ -48,16 +48,16 @@ class Chef
       end
 
       def for_each_user
-        rest.get_rest('/users').each_pair do |name, url|
+        rest.get('/users').each_pair do |name, url|
           yield name, url
         end
       end
 
       def for_each_organization
-        rest.get_rest('/organizations').each_pair do |name, url|
+        rest.get('/organizations').each_pair do |name, url|
           next unless (config[:org].nil? || config[:org] == name)
           ui.msg "Downloading organization object for #{name} from #{url}"
-          org = rest.get_rest(url)
+          org = rest.get(url)
           # Enterprise Chef 11 and below uses a pool of precreated
           # organizations to account for slow organization creation
           # using CouchDB. Thus, on server versions < 12 we want to
@@ -75,14 +75,14 @@ class Chef
       def download_user(username, url)
         ensure_dir("#{dest_dir}/users")
         File.open("#{dest_dir}/users/#{username}.json", 'w') do |file|
-          file.write(Chef::JSONCompat.to_json_pretty(rest.get_rest(url)))
+          file.write(Chef::JSONCompat.to_json_pretty(rest.get(url)))
         end
       end
 
       def download_user_acl(username)
         ensure_dir("#{dest_dir}/user_acls")
         File.open("#{dest_dir}/user_acls/#{username}.json", 'w') do |file|
-          file.write(Chef::JSONCompat.to_json_pretty(user_acl_rest.get_rest("users/#{username}/_acl")))
+          file.write(Chef::JSONCompat.to_json_pretty(user_acl_rest.get("users/#{username}/_acl")))
         end
       end
 
@@ -111,14 +111,14 @@ class Chef
       def download_org_members(name)
         ensure_dir("#{dest_dir}/organizations/#{name}")
         File.open("#{dest_dir}/organizations/#{name}/members.json", 'w') do |file|
-          file.write(Chef::JSONCompat.to_json_pretty(rest.get_rest("/organizations/#{name}/users")))
+          file.write(Chef::JSONCompat.to_json_pretty(rest.get("/organizations/#{name}/users")))
         end
       end
 
       def download_org_invitations(name)
         ensure_dir("#{dest_dir}/organizations/#{name}")
         File.open("#{dest_dir}/organizations/#{name}/invitations.json", 'w') do |file|
-          file.write(Chef::JSONCompat.to_json_pretty(rest.get_rest("/organizations/#{name}/association_requests")))
+          file.write(Chef::JSONCompat.to_json_pretty(rest.get("/organizations/#{name}/association_requests")))
         end
       end
 

--- a/lib/chef/knife/ec_base.rb
+++ b/lib/chef/knife/ec_base.rb
@@ -89,8 +89,8 @@ class Chef
 
         def org_admin
           rest = Chef::REST.new(Chef::Config.chef_server_url)
-          admin_users = rest.get_rest('groups/admins')['users']
-          org_members = rest.get_rest('users').map { |user| user['user']['username'] }
+          admin_users = rest.get('groups/admins')['users']
+          org_members = rest.get('users').map { |user| user['user']['username'] }
           admin_users.delete_if { |user| !org_members.include?(user) || user == 'pivotal' }
           if admin_users.empty?
             raise Chef::Knife::EcBase::NoAdminFound
@@ -109,8 +109,10 @@ class Chef
                     end
       end
 
+      # Since knife-ec-backup hasn't been updated to use API V1 keys endpoints
+      # we should explicitly as for V0.
       def rest
-        @rest ||= Chef::REST.new(server.root_url)
+        @rest ||= Chef::ServerAPI.new(server.root_url, {:api_version => "0"})
       end
 
       def user_acl_rest
@@ -119,7 +121,7 @@ class Chef
                            elsif server.supports_user_acls?
                              rest
                            elsif server.direct_account_access?
-                             Chef::REST.new("http://127.0.0.1:9465")
+                             Chef::ServerAPI.new("http://127.0.0.1:9465", {:api_version => "0"})
                            end
 
       end

--- a/lib/chef/knife/ec_restore.rb
+++ b/lib/chef/knife/ec_restore.rb
@@ -62,10 +62,10 @@ class Chef
 
       def create_organization(orgname)
         org = JSONCompat.from_json(File.read("#{dest_dir}/organizations/#{orgname}/org.json"))
-        rest.post_rest('organizations', org)
+        rest.post('organizations', org)
       rescue Net::HTTPServerException => e
         if e.response.code == "409"
-          rest.put_rest("organizations/#{orgname}", org)
+          rest.put("organizations/#{orgname}", org)
         else
           raise
         end
@@ -75,7 +75,7 @@ class Chef
         invitations = JSONCompat.from_json(File.read("#{dest_dir}/organizations/#{orgname}/invitations.json"))
         invitations.each do |invitation|
           begin
-            rest.post_rest("organizations/#{orgname}/association_requests", { 'user' => invitation['username'] })
+            rest.post("organizations/#{orgname}/association_requests", { 'user' => invitation['username'] })
           rescue Net::HTTPServerException => e
             if e.response.code != "409"
               ui.error("Cannot create invitation #{invitation['id']}")
@@ -89,9 +89,9 @@ class Chef
         members.each do |member|
           username = member['user']['username']
           begin
-            response = rest.post_rest("organizations/#{orgname}/association_requests", { 'user' => username })
+            response = rest.post("organizations/#{orgname}/association_requests", { 'user' => username })
             association_id = response["uri"].split("/").last
-            rest.put_rest("users/#{username}/association_requests/#{association_id}", { 'response' => 'accept' })
+            rest.put("users/#{username}/association_requests/#{association_id}", { 'response' => 'accept' })
           rescue Net::HTTPServerException => e
             if e.response.code != "409"
               raise
@@ -136,10 +136,10 @@ class Chef
             # Supply password for new user
             user_with_password = user.dup
             user_with_password['password'] = SecureRandom.hex
-            rest.post_rest('users', user_with_password)
+            rest.post('users', user_with_password)
           rescue Net::HTTPServerException => e
             if e.response.code == "409"
-              rest.put_rest("users/#{name}", user)
+              rest.put("users/#{name}", user)
             else
               raise
             end
@@ -304,12 +304,12 @@ class Chef
       end
 
       def put_acl(rest, url, acls)
-        old_acls = rest.get_rest(url)
+        old_acls = rest.get(url)
         old_acls = Chef::ChefFS::DataHandler::AclDataHandler.new.normalize(old_acls, nil)
         acls = Chef::ChefFS::DataHandler::AclDataHandler.new.normalize(acls, nil)
         if acls != old_acls
           Chef::ChefFS::FileSystem::AclEntry::PERMISSIONS.each do |permission|
-            rest.put_rest("#{url}/#{permission}", { permission => acls[permission] })
+            rest.put("#{url}/#{permission}", { permission => acls[permission] })
           end
         end
       end

--- a/spec/chef/knife/ec_backup_spec.rb
+++ b/spec/chef/knife/ec_backup_spec.rb
@@ -37,19 +37,19 @@ describe Chef::Knife::EcBackup do
 
   describe "#for_each_user" do
     it "iterates over remote users" do
-      allow(@rest).to receive(:get_rest).with("/users").and_return(USER_RESPONSE)
+      allow(@rest).to receive(:get).with("/users").and_return(USER_RESPONSE)
       expect{ |b| @knife.for_each_user(&b) }.to yield_successive_args(["foo", USER_RESPONSE["foo"]], ["bar", USER_RESPONSE["bar"]])
     end
   end
 
   describe "#for_each_organization" do
     before(:each) do
-      allow(@rest).to receive(:get_rest).with("/organizations").and_return(ORG_RESPONSE)
+      allow(@rest).to receive(:get).with("/organizations").and_return(ORG_RESPONSE)
     end
 
     it "iterates over remote organizations" do
-      allow(@rest).to receive(:get_rest).with("organizations/bar").and_return(org_response("bar"))
-      allow(@rest).to receive(:get_rest).with("organizations/foo").and_return(org_response("foo"))
+      allow(@rest).to receive(:get).with("organizations/bar").and_return(org_response("bar"))
+      allow(@rest).to receive(:get).with("organizations/foo").and_return(org_response("foo"))
       expect{ |b| @knife.for_each_organization(&b) }.to yield_successive_args(org_response("bar"), org_response("foo"))
     end
 
@@ -57,8 +57,8 @@ describe Chef::Knife::EcBackup do
       server = double('Chef::Server')
       allow(Chef::Server).to receive(:new).and_return(server)
       allow(server).to receive(:version).and_return(Gem::Version.new("11.12.3"))
-      allow(@rest).to receive(:get_rest).with("organizations/bar").and_return(org_response("bar"))
-      allow(@rest).to receive(:get_rest).with("organizations/foo").and_return(org_response("foo", true))
+      allow(@rest).to receive(:get).with("organizations/bar").and_return(org_response("bar"))
+      allow(@rest).to receive(:get).with("organizations/foo").and_return(org_response("foo", true))
       expect{ |b| @knife.for_each_organization(&b) }.to yield_successive_args(org_response("bar"))
     end
 
@@ -66,8 +66,8 @@ describe Chef::Knife::EcBackup do
       server = double('Chef::Server')
       allow(Chef::Server).to receive(:new).and_return(server)
       allow(server).to receive(:version).and_return(Gem::Version.new("12.0.0"))
-      allow(@rest).to receive(:get_rest).with("organizations/bar").and_return(org_response("bar"))
-      allow(@rest).to receive(:get_rest).with("organizations/foo").and_return(org_response("foo", true))
+      allow(@rest).to receive(:get).with("organizations/bar").and_return(org_response("bar"))
+      allow(@rest).to receive(:get).with("organizations/foo").and_return(org_response("foo", true))
       expect{ |b| @knife.for_each_organization(&b) }.to yield_successive_args(org_response("bar"),
                                                                               org_response("foo", true))
     end
@@ -79,13 +79,13 @@ describe Chef::Knife::EcBackup do
     let (:url) { "users/foo" }
 
     it "downloads a named user from the api" do
-      expect(@rest).to receive(:get_rest).with(url)
+      expect(@rest).to receive(:get).with(url)
       @knife.download_user(username, url)
     end
 
     it "writes it to a json file in the destination directory" do
       user_response = {"username" => "foo"}
-      allow(@rest).to receive(:get_rest).with(url).and_return(user_response)
+      allow(@rest).to receive(:get).with(url).and_return(user_response)
       @knife.download_user(username, url)
       expect(JSON.parse(File.read("/users/foo.json"))).to eq(user_response)
     end
@@ -96,13 +96,13 @@ describe Chef::Knife::EcBackup do
     let (:username) {"foo"}
 
     it "downloads a user acl from the API" do
-      expect(@rest).to receive(:get_rest).with("users/#{username}/_acl")
+      expect(@rest).to receive(:get).with("users/#{username}/_acl")
       @knife.download_user_acl(username)
     end
 
     it "writes it to a json file in the destination directory" do
       user_acl_response = {"create" => {}}
-      allow(@rest).to receive(:get_rest).with("users/#{username}/_acl").and_return(user_acl_response)
+      allow(@rest).to receive(:get).with("users/#{username}/_acl").and_return(user_acl_response)
       @knife.download_user_acl(username)
       expect(JSON.parse(File.read("/user_acls/foo.json"))).to eq(user_acl_response)
     end
@@ -130,12 +130,12 @@ describe Chef::Knife::EcBackup do
     }
 
     it "downloads org members for a given org" do
-      expect(@rest).to receive(:get_rest).with("/organizations/bob/users").and_return(users)
+      expect(@rest).to receive(:get).with("/organizations/bob/users").and_return(users)
       @knife.download_org_members("bob")
     end
 
     it "writes the org members to a JSON file" do
-      expect(@rest).to receive(:get_rest).with("/organizations/bob/users").and_return(users)
+      expect(@rest).to receive(:get).with("/organizations/bob/users").and_return(users)
       @knife.download_org_members("bob")
       expect(JSON.parse(File.read("/organizations/bob/members.json"))).to eq(users)
     end
@@ -145,12 +145,12 @@ describe Chef::Knife::EcBackup do
     include FakeFS::SpecHelpers
     let(:invites) { {"a json" => "maybe"} }
     it "downloads invitations for a given org" do
-      expect(@rest).to receive(:get_rest).with("/organizations/bob/association_requests").and_return(invites)
+      expect(@rest).to receive(:get).with("/organizations/bob/association_requests").and_return(invites)
       @knife.download_org_invitations("bob")
     end
 
     it "writes the invitations to a JSON file" do
-      expect(@rest).to receive(:get_rest).with("/organizations/bob/association_requests").and_return(invites)
+      expect(@rest).to receive(:get).with("/organizations/bob/association_requests").and_return(invites)
       @knife.download_org_invitations("bob")
       expect(JSON.parse(File.read("/organizations/bob/invitations.json"))).to eq(invites)
     end

--- a/spec/chef/knife/ec_base_spec.rb
+++ b/spec/chef/knife/ec_base_spec.rb
@@ -19,20 +19,20 @@ describe Chef::Knife::EcBase do
 
   context "org_admin" do
     it "selects an admin from an org" do
-      allow(@rest).to receive(:get_rest).with("groups/admins").and_return({"users" => ["bob"]})
-      allow(@rest).to receive(:get_rest).with("users").and_return([{"user" => { "username" => "bob"}}])
+      allow(@rest).to receive(:get).with("groups/admins").and_return({"users" => ["bob"]})
+      allow(@rest).to receive(:get).with("users").and_return([{"user" => { "username" => "bob"}}])
       expect(o.org_admin).to eq("bob")
     end
 
     it "refuses to return pivotal" do
-      allow(@rest).to receive(:get_rest).with("groups/admins").and_return({"users" => ["pivotal"]})
-      allow(@rest).to receive(:get_rest).with("users").and_return([{"user" => { "username" => "pivotal"}}])
+      allow(@rest).to receive(:get).with("groups/admins").and_return({"users" => ["pivotal"]})
+      allow(@rest).to receive(:get).with("users").and_return([{"user" => { "username" => "pivotal"}}])
       expect{o.org_admin}.to raise_error(Chef::Knife::EcBase::NoAdminFound)
     end
 
     it "refuses to return users not in the org" do
-      allow(@rest).to receive(:get_rest).with("groups/admins").and_return({"users" => ["bob"]})
-      allow(@rest).to receive(:get_rest).with("users").and_return([{"user" => { "username" => "sally"}}])
+      allow(@rest).to receive(:get).with("groups/admins").and_return({"users" => ["bob"]})
+      allow(@rest).to receive(:get).with("users").and_return([{"user" => { "username" => "sally"}}])
       expect{o.org_admin}.to raise_error(Chef::Knife::EcBase::NoAdminFound)
     end
   end

--- a/spec/chef/knife/ec_restore_spec.rb
+++ b/spec/chef/knife/ec_restore_spec.rb
@@ -33,15 +33,15 @@ describe Chef::Knife::EcRestore do
     it "posts a given org to the API from data on disk" do
       make_org "foo"
       org = JSON.parse(File.read("/organizations/foo/org.json"))
-      expect(@rest).to receive(:post_rest).with("organizations", org)
+      expect(@rest).to receive(:post).with("organizations", org)
       @knife.create_organization("foo")
     end
 
     it "updates a given org if it already exists" do
       make_org "foo"
       org = JSON.parse(File.read("/organizations/foo/org.json"))
-      allow(@rest).to receive(:post_rest).with("organizations", org).and_raise(net_exception(409))
-      expect(@rest).to receive(:put_rest).with("organizations/foo", org)
+      allow(@rest).to receive(:post).with("organizations", org).and_raise(net_exception(409))
+      expect(@rest).to receive(:put).with("organizations/foo", org)
       @knife.create_organization("foo")
     end
   end
@@ -51,15 +51,15 @@ describe Chef::Knife::EcRestore do
 
     it "reads the invitations from disk and posts them to the API" do
       make_org "foo"
-      expect(@rest).to receive(:post_rest).with("organizations/foo/association_requests", {"user" => "bob"})
-      expect(@rest).to receive(:post_rest).with("organizations/foo/association_requests", {"user" => "jane"})
+      expect(@rest).to receive(:post).with("organizations/foo/association_requests", {"user" => "bob"})
+      expect(@rest).to receive(:post).with("organizations/foo/association_requests", {"user" => "jane"})
       @knife.restore_open_invitations("foo")
     end
 
     it "does NOT fail if an inivitation already exists" do
       make_org "foo"
-      allow(@rest).to receive(:post_rest).with("organizations/foo/association_requests", {"user" => "bob"}).and_return(net_exception(409))
-      allow(@rest).to receive(:post_rest).with("organizations/foo/association_requests", {"user" => "jane"}).and_return(net_exception(409))
+      allow(@rest).to receive(:post).with("organizations/foo/association_requests", {"user" => "bob"}).and_return(net_exception(409))
+      allow(@rest).to receive(:post).with("organizations/foo/association_requests", {"user" => "jane"}).and_return(net_exception(409))
       expect {@knife.restore_open_invitations("foo")}.to_not raise_error
     end
   end
@@ -117,21 +117,21 @@ describe Chef::Knife::EcRestore do
 
     it "reads the user from disk and posts it to the API" do
       make_user "jane"
-      expect(@rest).to receive(:post_rest).with("users", anything)
+      expect(@rest).to receive(:post).with("users", anything)
       @knife.restore_users
     end
 
     it "sets a random password for users" do
       make_user "jane"
       # FIX ME: How can we test this better?
-      expect(@rest).to receive(:post_rest).with("users", {"username" => "jane", "password" => anything})
+      expect(@rest).to receive(:post).with("users", {"username" => "jane", "password" => anything})
       @knife.restore_users
     end
 
     it "updates the user if it already exists" do
       make_user "jane"
-      allow(@rest).to receive(:post_rest).with("users", anything).and_raise(net_exception(409))
-      expect(@rest).to receive(:put_rest).with("users/jane", {"username" => "jane"})
+      allow(@rest).to receive(:post).with("users", anything).and_raise(net_exception(409))
+      expect(@rest).to receive(:put).with("users/jane", {"username" => "jane"})
       @knife.restore_users
     end
   end


### PR DESCRIPTION
None of the knife-ec-backup code has been updated to use API V1. It must be forced to make V0 requests to work against a V1 supported Chef Server.

Ping @chef/lob 