### PR TITLE
Make EcKeyBase aware of the new location of db keys

### DIFF
--- a/lib/chef/knife/ec_key_base.rb
+++ b/lib/chef/knife/ec_key_base.rb
@@ -76,8 +76,14 @@ class Chef
           exit 1
         else
           running_config ||= JSON.parse(File.read("/etc/opscode/chef-server-running.json"))
-          config[:sql_user] ||= running_config['private_chef']['postgresql']['sql_user']
-          config[:sql_password] ||= running_config['private_chef']['postgresql']['sql_password']
+          # Latest versions of chef server put the database info under opscode-erchef.sql_user
+          hash_key = if running_config['private_chef']['opscode-erchef'].has_key? sql_user
+                       'opscode-erchef'
+                     else
+                       'postgresql'
+                     end
+          config[:sql_user] ||= running_config['private_chef'][hash_key]['sql_user']
+          config[:sql_password] ||= running_config['private_chef'][hash_key]['sql_password']
         end
       end
     end

--- a/lib/knife_ec_backup/version.rb
+++ b/lib/knife_ec_backup/version.rb
@@ -1,3 +1,3 @@
 module KnifeECBackup
-  VERSION = '2.0.4'
+  VERSION = '2.0.5'
 end


### PR DESCRIPTION
For consistency with other applications, we moved sql_user/sql_password from 'postgresql' to 'opscode-erchef' in node attributes.  This change makes EcKeyBase aware of that when loading its configuration. 

ping @chef/lob 
