### PR TITLE
2.0.6: use correctly quoted literal in EcKeyBase and add tests

### DIFF
--- a/lib/chef/knife/ec_key_base.rb
+++ b/lib/chef/knife/ec_key_base.rb
@@ -77,7 +77,7 @@ class Chef
         else
           running_config ||= JSON.parse(File.read("/etc/opscode/chef-server-running.json"))
           # Latest versions of chef server put the database info under opscode-erchef.sql_user
-          hash_key = if running_config['private_chef']['opscode-erchef'].has_key? sql_user
+          hash_key = if running_config['private_chef']['opscode-erchef'].has_key? 'sql_user'
                        'opscode-erchef'
                      else
                        'postgresql'

--- a/lib/knife_ec_backup/version.rb
+++ b/lib/knife_ec_backup/version.rb
@@ -1,3 +1,3 @@
 module KnifeECBackup
-  VERSION = '2.0.5'
+  VERSION = '2.0.6'
 end

--- a/spec/chef/knife/ec_key_base_spec.rb
+++ b/spec/chef/knife/ec_key_base_spec.rb
@@ -1,2 +1,40 @@
 require File.expand_path(File.join(File.dirname(__FILE__), "..", "..", "spec_helper"))
 require 'chef/knife/ec_key_base'
+
+class KeyBaseTester < Chef::Knife
+  include Chef::Knife::EcKeyBase
+end
+
+describe Chef::Knife::EcKeyBase do
+  let (:knife) { Chef::Knife::KeyBaseTester.new }
+
+  let(:running_server_postgresql_sql_config_json) {
+    '{"private_chef": { "opscode-erchef":{}, "postgresql": { "sql_user": "jiminy", "sql_password": "secret"} }}'
+  }
+
+
+  let(:running_server_erchef_config_json) {
+    '{"private_chef": { "opscode-erchef": { "sql_user": "cricket", "sql_password": "secrete"}, "postgresql" : {} }}'
+  }
+  describe "#load_config_from_file!" do
+    before(:each) do
+      pp knife.methods
+      @rest = double('rest')
+      allow(Chef::ServerAPI).to receive(:new).and_return(@rest)
+      allow(File).to receive(:exists?).and_return(true)
+    end
+    it "correctly sets sql options when they live under postgresql settings" do
+      allow(File).to receive(:read).and_return(running_server_postgresql_sql_config_json)
+      knife.load_config_from_file!
+      expect(knife.config[:sql_user]).to eq("jiminy")
+      expect(knife.config[:sql_password]).to eq("secret")
+    end
+    it "correctly sets sql options when they live under opscode-erchef settings" do
+      allow(File).to receive(:read).and_return(running_server_erchef_config_json)
+      knife.load_config_from_file!
+      expect(knife.config[:sql_user]).to eq("cricket")
+      expect(knife.config[:sql_password]).to eq("secrete")
+    end
+  end
+end
+


### PR DESCRIPTION
Fixed error in the previous update, and added some tests. 

ping @stevendanna 