### PR TITLE
Require Chef 12.6 for important ChefFS fixes

### DIFF
--- a/knife-ec-backup.gemspec
+++ b/knife-ec-backup.gemspec
@@ -19,7 +19,7 @@ Gem::Specification.new do |s|
   # s.add_dependency "mixlib-cli", ">= 1.2.2"
   s.add_dependency "sequel"
   s.add_dependency "pg"
-  s.add_dependency "chef", ">= 11.8"
+  s.add_dependency "chef", ">= 12.6"
 
   if RUBY_VERSION.index('1.9') == 0 then
     s.add_dependency "ohai", "< 8.0"


### PR DESCRIPTION
Chef 12.6 included b036d1542c10a6a4c0910b96a27404735134055a which fixes
a problem when downloading invitations.json. This was preventing a clean
backup when used with Chef 12.5.
