### PR TITLE
prevent "No such file or directory on remote or local" errors

### DIFF
--- a/lib/chef/knife/ec_backup.rb
+++ b/lib/chef/knife/ec_backup.rb
@@ -177,7 +177,7 @@ class Chef
       end
 
       def chef_fs_copy_pattern(pattern_str, chef_fs_config)
-        puts "Copying #{pattern_str}"
+        ui.msg "Copying #{pattern_str}"
         pattern = Chef::ChefFS::FilePattern.new(pattern_str)
         Chef::ChefFS::FileSystem.copy_to(pattern, chef_fs_config.chef_fs,
                                          chef_fs_config.local_fs, nil,

--- a/lib/chef/knife/ec_backup.rb
+++ b/lib/chef/knife/ec_backup.rb
@@ -169,11 +169,15 @@ class Chef
         end
       end
 
+      def normalize_path_name(path)
+        path=~/\.json\z/ ? path : path<<'.json'
+      end
+
       def chef_fs_paths(pattern_str, chef_fs_config, exclude=[])
         pattern = Chef::ChefFS::FilePattern.new(pattern_str)
         list = Chef::ChefFS::FileSystem.list(chef_fs_config.chef_fs, pattern)
         list = list.select { |entry| ! exclude.include?(entry.name) } if ! exclude.empty?
-        list.map {|entry| entry.path=~/\.json\z/ ? entry.path : entry.path<<'.json' }
+        list.map { |entry| normalize_path_name(entry.path) }
       end
 
       def chef_fs_copy_pattern(pattern_str, chef_fs_config)


### PR DESCRIPTION
This change fixes these errors:
```
ERROR: /acls/groups/0000000000005bd6d5ba77e7a8bbaa84: No such file or directory on remote or local
Copying /acls/groups/0000000000006f79f1b69382ab43385c
ERROR: /acls/groups/0000000000006f79f1b69382ab43385c: No such file or directory on remote or local
Copying /acls/groups/admins
ERROR: /acls/groups/admins: No such file or directory on remote or local
Copying /acls/groups/clients
ERROR: /acls/groups/clients: No such file or directory on remote or local
Copying /acls/groups/users
ERROR: /acls/groups/users: No such file or directory on remote or local
```

I have tested both backup and restore.