### PR TITLE
Swallow errors when restoring files that do not exist

### DIFF
--- a/lib/chef/knife/ec_restore.rb
+++ b/lib/chef/knife/ec_restore.rb
@@ -292,6 +292,7 @@ class Chef
           "/groups/#{group_name}.json"
         )
 
+        # Will throw NotFoundError if JSON file does not exist on disk. See below.
         members_json = Chef::ChefFS::FileSystem.resolve_path(
           chef_fs_config.local_fs,
           "/groups/#{group_name}.json"
@@ -308,6 +309,8 @@ class Chef
         end
 
         group.write(members.to_json)
+      rescue Chef::ChefFS::FileSystem::NotFoundError
+        Chef::Log.warn "Could not find #{group.display_path} on disk. Will not restore."
       end
 
       def put_acl(rest, url, acls)

--- a/lib/knife_ec_backup/version.rb
+++ b/lib/knife_ec_backup/version.rb
@@ -1,3 +1,3 @@
 module KnifeECBackup
-  VERSION = '2.0.6'
+  VERSION = '2.0.7'
 end

--- a/spec/chef/knife/ec_restore_spec.rb
+++ b/spec/chef/knife/ec_restore_spec.rb
@@ -135,4 +135,15 @@ describe Chef::Knife::EcRestore do
       @knife.restore_users
     end
   end
+
+  describe "#restore_group" do
+    context "when group is not present in backup" do
+      let(:chef_fs_config) { Chef::ChefFS::Config.new }
+      let(:group_name) { "bad_group" }
+
+      it "does not raise error" do
+        expect { @knife.restore_group(chef_fs_config, group_name) }.not_to raise_error
+      end
+    end
+  end
 end


### PR DESCRIPTION
Because knife-ec-backup does not capture Chef Server API version
metadata when backing up, its impossible to know which files to
restore. This commit fixes a bug where a backup/restore occurring prior
to the introduction of a certain file (in this case
public_key_read_access) would fail because that file (rightfully) does
not exist.

This commit is a stop-gap measure while a more wholistic solution is
created to more accurately restore backups.