### PR TITLE
exposing purge, dry_run options with sane defaults

### DIFF
--- a/README.md
+++ b/README.md
@@ -84,7 +84,7 @@ It is recommended that you run this from a frontend Enterprise Chef Server, you 
 
 # Subcommands
 
-## Common Option
+## Common Options
 
 The following options are supported across all subcommands:
 
@@ -101,6 +101,12 @@ The following options are supported across all subcommands:
 
   * `--sql_password`:
     The password for the sql_user.  (default: autoconfigured from /etc/opscode/chef-server-running.json)
+
+  * `--purge`:
+    Whether to sync deletions from backup source to restore destination. (default: false)
+
+  * `--dry-run`:
+    Report what actions would be taken without performing any. (default: false)
 
 ## knife ec backup DEST_DIR (options)
 

--- a/README.md
+++ b/README.md
@@ -88,19 +88,19 @@ It is recommended that you run this from a frontend Enterprise Chef Server, you 
 
 The following options are supported across all subcommands:
 
-  * `--sql_host`:
+  * `--sql-host`:
     The hostname of the Chef Server's postgresql server. (default: localhost)
 
-  * `--sql_port`:
+  * `--sql-port`:
     The postgresql listening port on the Chef Server. (default: 5432)
 
-  * `--sql_user`:
+  * `--sql-user`:
     The username of postgresql user with access to the opscode_chef
     database. (default: autoconfigured from
     /etc/opscode/chef-server-running.json)
 
-  * `--sql_password`:
-    The password for the sql_user.  (default: autoconfigured from /etc/opscode/chef-server-running.json)
+  * `--sql-password`:
+    The password for the sql-user.  (default: autoconfigured from /etc/opscode/chef-server-running.json)
 
   * `--purge`:
     Whether to sync deletions from backup source to restore destination. (default: false)

--- a/lib/chef/knife/ec_base.rb
+++ b/lib/chef/knife/ec_base.rb
@@ -78,6 +78,17 @@ class Chef
             :long => '--with-key-sql',
             :description => 'Try direct data base access for key table export/import.  Required to properly handle rotated keys.'
 
+          option :purge,
+            :long => '--purge',
+            :boolean => true | false,
+            :default => false,
+            :description => 'Syncs deletions from backup source to restore destination.'
+
+          option :dry_run,
+            :long => '--dry-run',
+            :boolean => true | false,
+            :default => false,
+            :description => 'Report what actions would be taken without performing any.'
         end
 
         attr_accessor :dest_dir


### PR DESCRIPTION
Exposing the `purge` and `dry_run` ChefFS options to knife-ec-backup.

Purge is particularly important because it syncs object deletions.

This has been tested and validated. 

Caveat: `purge` operates within the context of an organization and does not appear to sync deletions outside of an org.

Signed-off-by: Jeremy J. Miller <jm@chef.io>