### PR TITLE
substituting org_admin for user pivotal

### DIFF
--- a/lib/chef/knife/ec_backup.rb
+++ b/lib/chef/knife/ec_backup.rb
@@ -152,8 +152,8 @@ class Chef
           chef_fs_copy_pattern('/groups/public_key_read_access.json', chef_fs_config)
           chef_fs_copy_pattern('/groups/admins.json', chef_fs_config)
 
-          # Set Chef::Config to use an organization administrator
-          Chef::Config.node_name = org_admin
+          # Set Chef::Config to use 'pivotal' as opposed to org_admin
+          Chef::Config.node_name = 'pivotal'
 
           # Download the entire org skipping the billing-admins, public_key_read_access group ACLs and the groups themselves
           chef_fs_config = Chef::ChefFS::Config.new

--- a/lib/chef/knife/ec_backup.rb
+++ b/lib/chef/knife/ec_backup.rb
@@ -152,8 +152,7 @@ class Chef
           chef_fs_copy_pattern('/groups/public_key_read_access.json', chef_fs_config)
           chef_fs_copy_pattern('/groups/admins.json', chef_fs_config)
 
-          # Set Chef::Config to use 'pivotal' as opposed to org_admin
-          Chef::Config.node_name = 'pivotal'
+          Chef::Config.node_name = server.supports_defaulting_to_pivotal? ? 'pivotal' : org_admin
 
           # Download the entire org skipping the billing-admins, public_key_read_access group ACLs and the groups themselves
           chef_fs_config = Chef::ChefFS::Config.new

--- a/lib/chef/knife/ec_backup.rb
+++ b/lib/chef/knife/ec_backup.rb
@@ -152,7 +152,11 @@ class Chef
           chef_fs_copy_pattern('/groups/public_key_read_access.json', chef_fs_config)
           chef_fs_copy_pattern('/groups/admins.json', chef_fs_config)
 
-          Chef::Config.node_name = server.supports_defaulting_to_pivotal? ? 'pivotal' : org_admin
+          Chef::Config.node_name = if config[:skip_version]
+                                     org_admin
+                                   else
+                                     server.supports_defaulting_to_pivotal? ? 'pivotal' : org_admin
+                                   end
 
           # Download the entire org skipping the billing-admins, public_key_read_access group ACLs and the groups themselves
           chef_fs_config = Chef::ChefFS::Config.new

--- a/lib/chef/knife/ec_restore.rb
+++ b/lib/chef/knife/ec_restore.rb
@@ -229,11 +229,12 @@ class Chef
                                            proc { |entry| chef_fs_config.format_path(entry)})
           end
 
-          Chef::Config.node_name = org_admin
+          # Set Chef::Config to use 'pivotal' as opposed to org_admin
+          Chef::Config.node_name = 'pivotal'
 
           # Restore the entire org skipping the admin data and restoring groups and acls last
           ui.msg "Restoring the rest of the org"
-          Chef::Log.debug "Using admin user: #{org_admin}"
+          Chef::Log.debug 'Using user pivotal'
           chef_fs_config = Chef::ChefFS::Config.new
           top_level_paths = chef_fs_config.local_fs.children.select { |entry| entry.name != 'acls' && entry.name != 'groups' }.map { |entry| entry.path }
 

--- a/lib/chef/knife/ec_restore.rb
+++ b/lib/chef/knife/ec_restore.rb
@@ -229,12 +229,10 @@ class Chef
                                            proc { |entry| chef_fs_config.format_path(entry)})
           end
 
-          # Set Chef::Config to use 'pivotal' as opposed to org_admin
-          Chef::Config.node_name = 'pivotal'
+          Chef::Config.node_name = server.supports_defaulting_to_pivotal? ? 'pivotal' : org_admin
 
           # Restore the entire org skipping the admin data and restoring groups and acls last
           ui.msg "Restoring the rest of the org"
-          Chef::Log.debug 'Using user pivotal'
           chef_fs_config = Chef::ChefFS::Config.new
           top_level_paths = chef_fs_config.local_fs.children.select { |entry| entry.name != 'acls' && entry.name != 'groups' }.map { |entry| entry.path }
 

--- a/lib/chef/knife/ec_restore.rb
+++ b/lib/chef/knife/ec_restore.rb
@@ -229,7 +229,11 @@ class Chef
                                            proc { |entry| chef_fs_config.format_path(entry)})
           end
 
-          Chef::Config.node_name = server.supports_defaulting_to_pivotal? ? 'pivotal' : org_admin
+          Chef::Config.node_name = if config[:skip_version]
+                                     org_admin
+                                   else
+                                     server.supports_defaulting_to_pivotal? ? 'pivotal' : org_admin
+                                   end
 
           # Restore the entire org skipping the admin data and restoring groups and acls last
           ui.msg "Restoring the rest of the org"

--- a/lib/chef/server.rb
+++ b/lib/chef/server.rb
@@ -34,5 +34,9 @@ class Chef
     rescue
       false
     end
+
+    def supports_defaulting_to_pivotal?
+      version >= Gem::Version.new('12.1.0')
+    end
   end
 end


### PR DESCRIPTION
This change sets the `node_name` to `pivotal` for all operations as opposed to a value returned by `org_admin` function.  This should result in a more deterministic outcome for backup/restore operations.  The reasoning behind that is that more often than not the `pivotal` user will have the permissions necessary for the operation. 

Signed-off-by: Jeremy J. Miller <jm@chef.io>