### PR TITLE
jeremymv2/purge users

### DIFF
--- a/lib/chef/knife/ec_backup.rb
+++ b/lib/chef/knife/ec_backup.rb
@@ -54,7 +54,7 @@ class Chef
       def purge_users_on_backup
         return unless config[:purge]
         for_each_user_purge do |user|
-          ui.msg "Deleting user #{user} from local backup (purge in on)"
+          ui.msg "Deleting user #{user} from local backup (purge is on)"
           begin
             File.delete("#{dest_dir}/users/#{user}.json")
             File.delete("#{dest_dir}/user_acls/#{user}.json")

--- a/lib/chef/knife/ec_backup.rb
+++ b/lib/chef/knife/ec_backup.rb
@@ -58,8 +58,8 @@ class Chef
           begin
             File.delete("#{dest_dir}/users/#{user}.json")
             File.delete("#{dest_dir}/user_acls/#{user}.json")
-          rescue Errno::ENOENT
-            true
+          rescue Errno::ENOENT => e
+            ui.warn "Failed to find local #{user} data #{e}"
           end
         end
       end

--- a/lib/chef/knife/ec_base.rb
+++ b/lib/chef/knife/ec_base.rb
@@ -132,6 +132,10 @@ class Chef
         @rest ||= Chef::ServerAPI.new(server.root_url, {:api_version => "0"})
       end
 
+      def users
+        @users ||= rest.get('/users')
+      end
+
       def user_acl_rest
         @user_acl_rest ||= if config[:skip_version]
                              rest

--- a/lib/chef/knife/ec_base.rb
+++ b/lib/chef/knife/ec_base.rb
@@ -145,8 +145,11 @@ class Chef
       end
 
       def for_each_user_purge
-        # compare both ways looking for diffs
-        purge_list = local_user_list - remote_user_list | remote_user_list - local_user_list
+        purge_list = if opt_parser.default_argv[1] == 'backup'
+                       local_user_list - remote_user_list
+                     else
+                       remote_user_list - local_user_list
+                     end
         # failsafe - don't delete pivotal
         purge_list -= [:pivotal]
         purge_list.collect(&:to_s).each do |user|

--- a/lib/chef/knife/ec_base.rb
+++ b/lib/chef/knife/ec_base.rb
@@ -98,7 +98,6 @@ class Chef
         end
 
         attr_accessor :dest_dir
-        attr_accessor :users_for_purge
 
         def configure_chef
           super

--- a/lib/chef/knife/ec_base.rb
+++ b/lib/chef/knife/ec_base.rb
@@ -141,7 +141,7 @@ class Chef
       end
 
       def local_user_list
-        @local_users ||= Dir.glob("#{@dest_dir}/users/*\.json").map { |u| File.basename(u, '.json').to_sym }
+        @local_user_list ||= Dir.glob("#{@dest_dir}/users/*\.json").map { |u| File.basename(u, '.json').to_sym }
       end
 
       def for_each_user_purge

--- a/lib/chef/knife/ec_base.rb
+++ b/lib/chef/knife/ec_base.rb
@@ -147,8 +147,10 @@ class Chef
       def for_each_user_purge
         purge_list = if opt_parser.default_argv[1] == 'backup'
                        local_user_list - remote_user_list
-                     else
+                     elsif opt_parser.default_argv[1] == 'restore'
                        remote_user_list - local_user_list
+                     else
+                       raise 'for_each_user_purge only supports backup|restore subcommands'
                      end
         # failsafe - don't delete pivotal
         purge_list -= [:pivotal]

--- a/lib/chef/knife/ec_base.rb
+++ b/lib/chef/knife/ec_base.rb
@@ -24,6 +24,7 @@ class Chef
   class Knife
     module EcBase
       class NoAdminFound < Exception; end
+      class UnImplemented < Exception; end
 
       def self.included(includer)
         includer.class_eval do
@@ -97,6 +98,7 @@ class Chef
         end
 
         attr_accessor :dest_dir
+        attr_accessor :users_for_purge
 
         def configure_chef
           super
@@ -137,26 +139,16 @@ class Chef
       end
 
       def remote_user_list
-        @remote_user_list ||= remote_users.keys.map(&:to_sym)
+        @remote_user_list ||= remote_users.keys
       end
 
       def local_user_list
-        @local_user_list ||= Dir.glob("#{@dest_dir}/users/*\.json").map { |u| File.basename(u, '.json').to_sym }
+        @local_user_list ||= Dir.glob("#{dest_dir}/users/*\.json").map { |u| File.basename(u, '.json') }
       end
 
-      def for_each_user_purge
-        purge_list = if opt_parser.default_argv[1] == 'backup'
-                       local_user_list - remote_user_list
-                     elsif opt_parser.default_argv[1] == 'restore'
-                       remote_user_list - local_user_list
-                     else
-                       raise 'for_each_user_purge only supports backup|restore subcommands'
-                     end
-        # failsafe - don't delete pivotal
-        purge_list -= [:pivotal]
-        purge_list.collect(&:to_s).each do |user|
-          yield user
-        end
+      def users_for_purge
+        # not itended to be called from ec_base
+        raise Chef::Knife::EcBase::UnImplemented
       end
 
       def user_acl_rest

--- a/lib/chef/knife/ec_restore.rb
+++ b/lib/chef/knife/ec_restore.rb
@@ -145,6 +145,15 @@ class Chef
             end
           end
         end
+        purge_users_on_restore
+      end
+
+      def purge_users_on_restore
+        return unless config[:purge]
+        for_each_user_purge do |user|
+          ui.msg "Deleting user #{user} from remote (purge in on)"
+          rest.delete("/users/#{user}")
+        end
       end
 
       def ec_key_import

--- a/lib/chef/knife/ec_restore.rb
+++ b/lib/chef/knife/ec_restore.rb
@@ -148,9 +148,18 @@ class Chef
         purge_users_on_restore
       end
 
+      def users_for_purge
+        purge_list = remote_user_list - local_user_list
+        # failsafe - don't delete pivotal
+        purge_list -= ['pivotal']
+        purge_list.each do |user|
+          yield user
+        end
+      end
+
       def purge_users_on_restore
         return unless config[:purge]
-        for_each_user_purge do |user|
+        users_for_purge do |user|
           ui.msg "Deleting user #{user} from remote (purge is on)"
           begin
             rest.delete("/users/#{user}")

--- a/lib/chef/knife/ec_restore.rb
+++ b/lib/chef/knife/ec_restore.rb
@@ -152,7 +152,11 @@ class Chef
         return unless config[:purge]
         for_each_user_purge do |user|
           ui.msg "Deleting user #{user} from remote (purge in on)"
-          rest.delete("/users/#{user}")
+          begin
+            rest.delete("/users/#{user}")
+          rescue Net::HTTPServerException => e
+            ui.warn "Failed deleting user #{user} from remote #{e}"
+          end
         end
       end
 

--- a/lib/chef/knife/ec_restore.rb
+++ b/lib/chef/knife/ec_restore.rb
@@ -151,7 +151,7 @@ class Chef
       def purge_users_on_restore
         return unless config[:purge]
         for_each_user_purge do |user|
-          ui.msg "Deleting user #{user} from remote (purge in on)"
+          ui.msg "Deleting user #{user} from remote (purge is on)"
           begin
             rest.delete("/users/#{user}")
           rescue Net::HTTPServerException => e


### PR DESCRIPTION
I noticed while performing backup & restores that user deletions are not purged when using the `purge` option.  `purge` was not implemented in `knife-ec-backup` only in `ChefFS` - users and user_acls are handled outside of `ChefFS`, in `knife-ec-backup`. 

If we want user deletions to sync, this change adds the `purge` capability for users and user_acls in `knife-ec-backup`.

It requires https://github.com/chef/knife-ec-backup/pull/87 to be merged first to add the `purge` option.