### PR TITLE
add Gemfile.lock

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,4 @@
-
 *~
-Gemfile.lock
 vendor/
 .bundle
 coverage

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,0 +1,171 @@
+GIT
+  remote: https://github.com/chef/chef_secrets
+  revision: 3ada796f85085bc3d6777f0bc355ce9345db7adf
+  specs:
+    veil (0.3.0)
+      bcrypt (~> 3.1)
+      pbkdf2
+
+PATH
+  remote: .
+  specs:
+    knife-ec-backup (2.0.7)
+      chef (>= 11.8)
+      pg
+      sequel
+      veil
+
+GEM
+  remote: http://rubygems.org/
+  specs:
+    addressable (2.5.0)
+      public_suffix (~> 2.0, >= 2.0.2)
+    bcrypt (3.1.11)
+    builder (3.2.3)
+    chef (12.19.36)
+      addressable
+      bundler (>= 1.10)
+      chef-config (= 12.19.36)
+      chef-zero (>= 4.8)
+      diff-lcs (~> 1.2, >= 1.2.4)
+      erubis (~> 2.7)
+      ffi-yajl (~> 2.2)
+      highline (~> 1.6, >= 1.6.9)
+      iniparse (~> 1.4)
+      mixlib-archive (~> 0.4)
+      mixlib-authentication (~> 1.4)
+      mixlib-cli (~> 1.7)
+      mixlib-log (~> 1.3)
+      mixlib-shellout (~> 2.0)
+      net-sftp (~> 2.1, >= 2.1.2)
+      net-ssh (>= 2.9, < 5.0)
+      net-ssh-multi (~> 1.2, >= 1.2.1)
+      ohai (>= 8.6.0.alpha.1, < 13)
+      plist (~> 3.2)
+      proxifier (~> 1.0)
+      rspec-core (~> 3.5)
+      rspec-expectations (~> 3.5)
+      rspec-mocks (~> 3.5)
+      rspec_junit_formatter (~> 0.2.0)
+      serverspec (~> 2.7)
+      specinfra (~> 2.10)
+      syslog-logger (~> 1.6)
+      uuidtools (~> 2.1.5)
+    chef-config (12.19.36)
+      addressable
+      fuzzyurl
+      mixlib-config (~> 2.0)
+      mixlib-shellout (~> 2.0)
+    chef-zero (5.3.1)
+      ffi-yajl (~> 2.2)
+      hashie (>= 2.0, < 4.0)
+      mixlib-log (~> 1.3)
+      rack (~> 2.0)
+      uuidtools (~> 2.1)
+    diff-lcs (1.3)
+    docile (1.1.5)
+    erubis (2.7.0)
+    fakefs (0.10.2)
+    ffi (1.9.18)
+    ffi-yajl (2.3.0)
+      libyajl2 (~> 1.2)
+    fuzzyurl (0.9.0)
+    hashie (3.5.5)
+    highline (1.7.8)
+    iniparse (1.4.2)
+    ipaddress (0.8.3)
+    json (2.0.3)
+    libyajl2 (1.2.0)
+    mixlib-archive (0.4.1)
+      mixlib-log
+    mixlib-authentication (1.4.1)
+      mixlib-log
+    mixlib-cli (1.7.0)
+    mixlib-config (2.2.4)
+    mixlib-log (1.7.1)
+    mixlib-shellout (2.2.7)
+    multi_json (1.12.1)
+    net-scp (1.2.1)
+      net-ssh (>= 2.6.5)
+    net-sftp (2.1.2)
+      net-ssh (>= 2.6.5)
+    net-ssh (4.1.0)
+    net-ssh-gateway (2.0.0)
+      net-ssh (>= 4.0.0)
+    net-ssh-multi (1.2.1)
+      net-ssh (>= 2.6.5)
+      net-ssh-gateway (>= 1.2.0)
+    net-telnet (0.1.1)
+    ohai (8.23.0)
+      chef-config (>= 12.5.0.alpha.1, < 13)
+      ffi (~> 1.9)
+      ffi-yajl (~> 2.2)
+      ipaddress
+      mixlib-cli
+      mixlib-config (~> 2.0)
+      mixlib-log (>= 1.7.1, < 2.0)
+      mixlib-shellout (~> 2.0)
+      plist (~> 3.1)
+      systemu (~> 2.6.4)
+      wmi-lite (~> 1.0)
+    pbkdf2 (0.1.0)
+    pg (0.20.0)
+    plist (3.2.0)
+    proxifier (1.0.3)
+    public_suffix (2.0.5)
+    rack (2.0.1)
+    rake (12.0.0)
+    rspec (3.5.0)
+      rspec-core (~> 3.5.0)
+      rspec-expectations (~> 3.5.0)
+      rspec-mocks (~> 3.5.0)
+    rspec-core (3.5.4)
+      rspec-support (~> 3.5.0)
+    rspec-expectations (3.5.0)
+      diff-lcs (>= 1.2.0, < 2.0)
+      rspec-support (~> 3.5.0)
+    rspec-its (1.2.0)
+      rspec-core (>= 3.0.0)
+      rspec-expectations (>= 3.0.0)
+    rspec-mocks (3.5.0)
+      diff-lcs (>= 1.2.0, < 2.0)
+      rspec-support (~> 3.5.0)
+    rspec-support (3.5.0)
+    rspec_junit_formatter (0.2.3)
+      builder (< 4)
+      rspec-core (>= 2, < 4, != 2.12.0)
+    sequel (4.44.0)
+    serverspec (2.38.0)
+      multi_json
+      rspec (~> 3.0)
+      rspec-its
+      specinfra (~> 2.53)
+    sfl (2.3)
+    simplecov (0.14.1)
+      docile (~> 1.1.0)
+      json (>= 1.8, < 3)
+      simplecov-html (~> 0.10.0)
+    simplecov-html (0.10.0)
+    specinfra (2.67.3)
+      net-scp
+      net-ssh (>= 2.7, < 5.0)
+      net-telnet
+      sfl
+    syslog-logger (1.6.8)
+    systemu (2.6.5)
+    uuidtools (2.1.5)
+    wmi-lite (1.0.0)
+
+PLATFORMS
+  ruby
+
+DEPENDENCIES
+  fakefs
+  knife-ec-backup!
+  rake
+  rspec
+  simplecov
+  veil!
+
+BUNDLED WITH
+   1.13.6


### PR DESCRIPTION
We are checking in Gemfile.lock to help prevent chef-server from shipping with multiple versions of Chef since it currently requires knife-ec-backup from master and thus does a `bundle install` on it during the build.

We understand this is a bit ugly; however, sorting out gem management in Chef Server is a bit of a project.

Signed-off-by: Stephan Renatus <srenatus@chef.io>