### PR TITLE
Update Gemfile.lock

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -9,7 +9,7 @@ GIT
 PATH
   remote: .
   specs:
-    knife-ec-backup (2.0.7)
+    knife-ec-backup (2.1.0)
       chef (>= 11.8)
       pg
       sequel
@@ -18,7 +18,7 @@ PATH
 GEM
   remote: http://rubygems.org/
   specs:
-    addressable (2.5.0)
+    addressable (2.5.1)
       public_suffix (~> 2.0, >= 2.0.2)
     bcrypt (3.1.11)
     builder (3.2.3)
@@ -56,7 +56,7 @@ GEM
       fuzzyurl
       mixlib-config (~> 2.0)
       mixlib-shellout (~> 2.0)
-    chef-zero (5.3.1)
+    chef-zero (5.3.2)
       ffi-yajl (~> 2.2)
       hashie (>= 2.0, < 4.0)
       mixlib-log (~> 1.3)
@@ -110,7 +110,7 @@ GEM
       wmi-lite (~> 1.0)
     pbkdf2 (0.1.0)
     pg (0.20.0)
-    plist (3.2.0)
+    plist (3.3.0)
     proxifier (1.0.3)
     public_suffix (2.0.5)
     rack (2.0.1)
@@ -134,7 +134,7 @@ GEM
     rspec_junit_formatter (0.2.3)
       builder (< 4)
       rspec-core (>= 2, < 4, != 2.12.0)
-    sequel (4.44.0)
+    sequel (4.46.0)
     serverspec (2.38.0)
       multi_json
       rspec (~> 3.0)
@@ -146,7 +146,7 @@ GEM
       json (>= 1.8, < 3)
       simplecov-html (~> 0.10.0)
     simplecov-html (0.10.0)
-    specinfra (2.67.3)
+    specinfra (2.67.9)
       net-scp
       net-ssh (>= 2.7, < 5.0)
       net-telnet
@@ -168,4 +168,4 @@ DEPENDENCIES
   veil!
 
 BUNDLED WITH
-   1.13.6
+   1.14.6


### PR DESCRIPTION
We failed to update Gemfile.lock with the most recent version bump,
which means it was being re-resolved during the omnibus-build in Chef
Server.

We are solving this in Chef Server by adding --local to the install
for now.

I think in the long run we want to remove this lockfile completely
since knife-ec-backup and its deps should be locked at a higher level
in the application that depends on it.

Signed-off-by: Steven Danna <steve@chef.io>