### PR TITLE
Hardcode PERMISSIONS list

### DIFF
--- a/lib/chef/knife/ec_restore.rb
+++ b/lib/chef/knife/ec_restore.rb
@@ -351,12 +351,13 @@ class Chef
         Chef::Log.warn "Could not find #{group.display_path} on disk. Will not restore."
       end
 
+      PERMISSIONS = %w{create read update delete grant}.freeze
       def put_acl(rest, url, acls)
         old_acls = rest.get(url)
         old_acls = Chef::ChefFS::DataHandler::AclDataHandler.new.normalize(old_acls, nil)
         acls = Chef::ChefFS::DataHandler::AclDataHandler.new.normalize(acls, nil)
         if acls != old_acls
-          Chef::ChefFS::FileSystem::AclEntry::PERMISSIONS.each do |permission|
+          PERMISSIONS.each do |permission|
             rest.put("#{url}/#{permission}", { permission => acls[permission] })
           end
         end


### PR DESCRIPTION
The location of the previously used constant is different in Chef 12
and Chef 13. While we could account for that, it seems better to avoid
the dependency since that list of permissions is unlikely to change.

Signed-off-by: Steven Danna <steve@chef.io>