### PR TITLE
minor travis improvements

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,12 +1,12 @@
-# Lets actually use our tests! :smile:
+sudo: false
 branches:
   only:
     - master
 
-sudo: required
 language: ruby
 cache: bundler
 dist: trusty
+rvm: 2.3.3
 
 before_install:
 - gem update --system
@@ -16,6 +16,8 @@ before_install:
 script:
   - bundle exec rake
 
-matrix:
-  include:
-    - rvm: 2.3.3
+env:
+  matrix:
+  - TRAVIS_CHEF_VERSION="~> 12.0" # latest 12.x.y
+  - TRAVIS_CHEF_VERSION="~> 13.0" # latest 13.x.y
+  - TRAVIS_CHEF_VERSION="branch:v12.19.36" # chef-server stable

--- a/Gemfile
+++ b/Gemfile
@@ -3,6 +3,14 @@ source :rubygems
 gem 'veil', git: 'https://github.com/chef/chef_secrets'
 gemspec
 
+if vsn = ENV['TRAVIS_CHEF_VERSION']
+  if m = /branch:(?<branch>.*)$/.match(vsn)
+    gem 'chef', git: 'https://github.com/chef/chef', branch: m[:branch]
+  else
+    gem 'chef', vsn
+  end
+end
+
 group :development do
   gem 'rspec'
   gem 'rake'

--- a/README.md
+++ b/README.md
@@ -1,4 +1,6 @@
 # knife EC backup
+[![Build Status Master](https://travis-ci.org/chef/knife-ec-backup.svg?branch=master)](https://travis-ci.org/chef/knife-ec-backup)
+[![Gem Version](https://badge.fury.io/rb/knife-ec-backup.svg)](https://badge.fury.io/rb/knife-ec-backup)
 
 # Description
 
@@ -32,7 +34,7 @@ the key data.
 
 ## Chef Server Install (Recommended)
 
-This gem is installed with chef-server-core 12.0.0 and newer. 
+This gem is installed with chef-server-core 12.0.0 and newer.
 
 For Private Chef 11 (or Enterprise Chef 11) you'll need to download and build
 locally to get the correct dependencies, either with `git clone` or by


### PR DESCRIPTION
* don't stick to deprecated env
* remove rvm matrix thing
* build for chef 12 and 13
* README: add badges (travis and rubygems version)

I'm not sure if the multiple version tests really help, but it doesn't seem like the worst idea. (Anyhow, it doesn't come at a high cost, I think.)