### PR TITLE
added rescue for Chef::ChefFS::FileSystem::NotFoundError

### DIFF
--- a/lib/chef/knife/ec_backup.rb
+++ b/lib/chef/knife/ec_backup.rb
@@ -241,11 +241,9 @@ class Chef
                                          chef_fs_config.local_fs, nil,
                                          config, ui,
                                          proc { |entry| chef_fs_config.format_path(entry) })
-      rescue Net::HTTPServerException => ex
-        knife_ec_error_handler.add(ex)
-      rescue Chef::ChefFS::FileSystem::NotFoundError => ex
-        knife_ec_error_handler.add(ex)
-      rescue Chef::ChefFS::FileSystem::OperationFailedError => ex
+      rescue Net::HTTPServerException,
+             Chef::ChefFS::FileSystem::NotFoundError,
+             Chef::ChefFS::FileSystem::OperationFailedError => ex
         knife_ec_error_handler.add(ex)
       end
     end

--- a/lib/chef/knife/ec_backup.rb
+++ b/lib/chef/knife/ec_backup.rb
@@ -243,6 +243,10 @@ class Chef
                                          proc { |entry| chef_fs_config.format_path(entry) })
       rescue Net::HTTPServerException => ex
         knife_ec_error_handler.add(ex)
+      rescue Chef::ChefFS::FileSystem::NotFoundError => ex
+        knife_ec_error_handler.add(ex)
+      rescue Chef::ChefFS::FileSystem::OperationFailedError => ex
+        knife_ec_error_handler.add(ex)
       end
     end
   end

--- a/lib/chef/knife/ec_error_handler.rb
+++ b/lib/chef/knife/ec_error_handler.rb
@@ -80,7 +80,10 @@ class Chef
             reason: ex.reason
           )
         elsif ex.instance_of?(Chef::ChefFS::FileSystem::OperationFailedError)
-          msg.merge!(message: ex.message)
+          msg.merge!(
+            entry: ex.entry,
+            operation: ex.operation
+          )
         end
 
         lock_file(@err_file, 'a') do |f|

--- a/lib/chef/knife/ec_error_handler.rb
+++ b/lib/chef/knife/ec_error_handler.rb
@@ -69,10 +69,18 @@ class Chef
         }
 
         if ex.respond_to?(:chef_rest_request=) && ex.chef_rest_request
-          msg.merge!( {
+          msg.merge!(
             req_path: ex.chef_rest_request.path,
             req_method: ex.chef_rest_request.method
-          })
+          )
+        elsif ex.instance_of?(Chef::ChefFS::FileSystem::NotFoundError)
+          msg.merge!(
+            entry: ex.entry,
+            cause: ex.cause,
+            reason: ex.reason
+          )
+        elsif ex.instance_of?(Chef::ChefFS::FileSystem::OperationFailedError)
+          msg.merge!(message: ex.message)
         end
 
         lock_file(@err_file, 'a') do |f|

--- a/lib/chef/knife/ec_restore.rb
+++ b/lib/chef/knife/ec_restore.rb
@@ -299,6 +299,10 @@ class Chef
                                          proc { |entry| chef_fs_config.format_path(entry) })
       rescue Net::HTTPServerException => ex
         knife_ec_error_handler.add(ex)
+      rescue Chef::ChefFS::FileSystem::NotFoundError => ex
+        knife_ec_error_handler.add(ex)
+      rescue Chef::ChefFS::FileSystem::OperationFailedError => ex
+        knife_ec_error_handler.add(ex)
       end
 
       # Takes an array of group objects

--- a/lib/chef/knife/ec_restore.rb
+++ b/lib/chef/knife/ec_restore.rb
@@ -297,11 +297,9 @@ class Chef
                                          chef_fs_config.chef_fs, nil,
                                          config, ui,
                                          proc { |entry| chef_fs_config.format_path(entry) })
-      rescue Net::HTTPServerException => ex
-        knife_ec_error_handler.add(ex)
-      rescue Chef::ChefFS::FileSystem::NotFoundError => ex
-        knife_ec_error_handler.add(ex)
-      rescue Chef::ChefFS::FileSystem::OperationFailedError => ex
+      rescue Net::HTTPServerException,
+             Chef::ChefFS::FileSystem::NotFoundError,
+             Chef::ChefFS::FileSystem::OperationFailedError => ex
         knife_ec_error_handler.add(ex)
       end
 

--- a/spec/chef/knife/ec_backup_spec.rb
+++ b/spec/chef/knife/ec_backup_spec.rb
@@ -1,6 +1,9 @@
 require File.expand_path(File.join(File.dirname(__FILE__), "..", "..", "spec_helper"))
 require 'chef/knife/ec_backup'
 require 'fakefs/spec_helpers'
+require_relative './ec_error_handler_spec'
+require "chef/chef_fs/file_system/repository/chef_repository_file_system_root_dir"
+
 
 describe Chef::Knife::EcBackup do
   let(:dest_dir) { Dir.mktmpdir }
@@ -162,6 +165,28 @@ describe Chef::Knife::EcBackup do
     end
   end
 
+  describe "#chef_fs_copy_pattern" do
+    context "when there are Filesystem errors" do
+      let(:ec_error_handler) { double("Chef::Knife::EcErrorHandler") }
+      let(:cheffs_config) { double("Chef::ChefFS::Config") }
+      let(:cheffs_files) { double("Chef::ChefFS::FileSystem") }
+      let(:cheffs_local_fs) { double('Chef::ChefFS::FileSystem::Repository::ChefRepositoryFileSystemRootDir') }
+      let(:chef_fs) { double('applefs') }
+
+      it "adds exceptions to error handler" do
+        exception = cheffs_filesystem_exception('NotFoundError')
+        allow(Chef::Knife::EcErrorHandler).to receive(:new).and_return(ec_error_handler)
+        allow(Chef::ChefFS::Config).to receive(:new).and_return(cheffs_config)
+        allow(Chef::ChefFS::FileSystem::Repository::ChefRepositoryFileSystemRootDir).to receive(:new).and_return(cheffs_local_fs)
+        allow(Chef::ChefFS::FileSystem).to receive(:copy_to).with(any_args).and_raise(exception)
+        allow(cheffs_config).to receive(:chef_fs).and_return(chef_fs)
+        allow(cheffs_config).to receive(:local_fs).and_return(cheffs_local_fs)
+        expect(ec_error_handler).to receive(:add).at_least(1).with(exception)
+        @knife.chef_fs_copy_pattern('bob', cheffs_config)
+      end
+    end
+  end
+
   describe "#write_org_object_to_disk" do
     include FakeFS::SpecHelpers
     it "writes the given object to disk" do
@@ -205,7 +230,6 @@ describe Chef::Knife::EcBackup do
         @knife.download_org_members("bob")
       end
     end
-
   end
 
   describe "#download_org_inivitations" do

--- a/spec/chef/knife/ec_error_handler_spec.rb
+++ b/spec/chef/knife/ec_error_handler_spec.rb
@@ -2,11 +2,24 @@ require File.expand_path(File.join(File.dirname(__FILE__), "..", "..", "spec_hel
 require 'chef/knife/ec_error_handler'
 require 'chef/knife/ec_backup'
 require 'chef/knife/ec_restore'
+require 'chef/chef_fs/config'
+require 'chef/chef_fs/file_system'
 require 'fakefs/spec_helpers'
 
 def net_exception(code)
   s = double("status", :code => code.to_s)
   Net::HTTPServerException.new("I'm not real!", s)
+end
+
+def cheffs_filesystem_exception(type)
+  case type
+  when 'NotFoundError'
+    Chef::ChefFS::FileSystem::NotFoundError.new(self, '/boop', 'I\'m not real!')
+  when 'OperationFailedError'
+    Chef::ChefFS::FileSystem::OperationFailedError.new(:read, self, '/boop', 'I\'m not real!')
+  else
+    raise RuntimeError, 'invalid type passed'
+  end
 end
 
 describe Chef::Knife::EcErrorHandler do
@@ -69,6 +82,16 @@ Error Summary Report
   "message": "I'm not real!",
   "backtrace": null,
   "exception": "Net::HTTPServerException"
+}{
+  "timestamp": "1988-04-17 00:00:00 +0000",
+  "message": "I'm not real!",
+  "backtrace": null,
+  "exception": "Chef::ChefFS::FileSystem::NotFoundError"
+}{
+  "timestamp": "1988-04-17 00:00:00 +0000",
+  "message": "I'm not real!",
+  "backtrace": null,
+  "exception": "Chef::ChefFS::FileSystem::OperationFailedError"
 }
 EOF
     err_file = @knife_ec_error_handler.err_file
@@ -83,6 +106,8 @@ EOF
     @knife_ec_error_handler.add(net_exception(409))
     @knife_ec_error_handler.add(net_exception(404))
     @knife_ec_error_handler.add(net_exception(123))
+    @knife_ec_error_handler.add(cheffs_filesystem_exception('NotFoundError'))
+    @knife_ec_error_handler.add(cheffs_filesystem_exception('OperationFailedError'))
     expect(File.read(err_file)).to match mock_content.strip
   end
 end

--- a/spec/chef/knife/ec_error_handler_spec.rb
+++ b/spec/chef/knife/ec_error_handler_spec.rb
@@ -14,9 +14,9 @@ end
 def cheffs_filesystem_exception(type)
   case type
   when 'NotFoundError'
-    Chef::ChefFS::FileSystem::NotFoundError.new(self, '/boop', 'I\'m not real!')
+    Chef::ChefFS::FileSystem::NotFoundError.new('/boop', 'The exception', 'The reason')
   when 'OperationFailedError'
-    Chef::ChefFS::FileSystem::OperationFailedError.new(:read, self, '/boop', 'I\'m not real!')
+    Chef::ChefFS::FileSystem::OperationFailedError.new(:read, '/boop', 'The exception', 'The reason')
   else
     raise RuntimeError, 'invalid type passed'
   end
@@ -84,14 +84,19 @@ Error Summary Report
   "exception": "Net::HTTPServerException"
 }{
   "timestamp": "1988-04-17 00:00:00 +0000",
-  "message": "I'm not real!",
+  "message": "The reason",
   "backtrace": null,
-  "exception": "Chef::ChefFS::FileSystem::NotFoundError"
+  "exception": "Chef::ChefFS::FileSystem::NotFoundError",
+  "entry": "/boop",
+  "cause": "The exception",
+  "reason": "The reason"
 }{
   "timestamp": "1988-04-17 00:00:00 +0000",
-  "message": "I'm not real!",
+  "message": "The reason",
   "backtrace": null,
-  "exception": "Chef::ChefFS::FileSystem::OperationFailedError"
+  "exception": "Chef::ChefFS::FileSystem::OperationFailedError",
+  "entry": "/boop",
+  "operation": "read"
 }
 EOF
     err_file = @knife_ec_error_handler.err_file


### PR DESCRIPTION
Recently encountered a bizarro backup failure on this specific entry: ` /acls/cookbook_artifacts/apache2.json` I don't think cookbook_artifacts have acls so I'm not certain how that scenario came about..

Regardless, it was dying with this:
```
DEBUG: Initiating GET to https://redacted/organizations/redacted/cookbook_artifacts/apache2/_acl
DEBUG: ---- HTTP Request Header Data: ----
DEBUG: Accept: application/json
DEBUG: Accept-Encoding: gzip;q=1.0,deflate;q=0.6,identity;q=0.3
DEBUG: X-Ops-Server-API-Version: 0
DEBUG: X-OPS-SIGN: algorithm=sha1;version=1.1;
DEBUG: X-OPS-USERID: pivotal
DEBUG: X-OPS-TIMESTAMP: 2017-07-28T19:48:32Z
DEBUG: X-OPS-CONTENT-HASH: 2jmj7l5rSw0yVb/vlWAYkK/YBwk=
DEBUG: X-OPS-AUTHORIZATION-1: AoYfA8TiDbC1bc787vvd7xtqe9y3rSaTIWYPvZGsaba7cbqIOzJZ2q712Pv8
DEBUG: X-OPS-AUTHORIZATION-2: F9E3YQhKaFnIsIOkKob8OQpH21x8MTAtGQFpRDWpDq5FjeOg+weOHpY8FqHE
DEBUG: X-OPS-AUTHORIZATION-3: yyKsCZgGWk9vldV1Crhq0xsDpHnMQBoSYuJVzMwdbaeUkBpzV3Gi2aK5CUuf
DEBUG: X-OPS-AUTHORIZATION-4: /+Ed1z/R9RQybNSr46OkQNxTQg81PsX/T1bicouUomvmjRE8IA5FzSO7toQp
DEBUG: X-OPS-AUTHORIZATION-5: ga8qN1Fkztv2ew6CfWKKznfOoOLoJ/akbrXBPDExTimuTQITA4VmbuC/G2me
DEBUG: X-OPS-AUTHORIZATION-6: d/ruqNqd3VJEJPHp4pejcF3htgl29K8wxMpbtiiLfA==
DEBUG: HOST: ip-10-194-208-94.us-west-2.compute.internal:443
DEBUG: X-REMOTE-REQUEST-ID: ad856a3f-6e8a-4a87-8afa-1f44c31a9067
DEBUG: x-ops-request-source: web
DEBUG: ---- End HTTP Request Header Data ----
DEBUG: ---- HTTP Status and Header Data: ----
DEBUG: HTTP 1.1 404 Object Not Found
DEBUG: server: openresty/1.11.2.1
DEBUG: date: Fri, 28 Jul 2017 19:48:32 GMT
DEBUG: content-length: 23
DEBUG: connection: close
DEBUG: x-ops-server-api-version: {"min_version":"0","max_version":"1","request_version":"0","response_version":"0"}
DEBUG: x-ops-api-info: flavor=cs;version=12.0.0;oc_erchef=12.15.7+20170619072446
DEBUG: ---- End HTTP Status/Header Data ----
DEBUG: ---- HTTP Response Body ----
DEBUG: {"error":["not_found"]}
DEBUG: ---- End HTTP Response Body -----
DEBUG: Chef::HTTP calling Chef::HTTP::ValidateContentLength#handle_response
DEBUG: Content-Length validated correctly.
DEBUG: Chef::HTTP calling Chef::HTTP::APIVersions#handle_response
DEBUG: Chef::HTTP calling Chef::HTTP::RemoteRequestID#handle_response
DEBUG: Chef::HTTP calling Chef::HTTP::Authenticator#handle_response
DEBUG: Chef::HTTP calling Chef::HTTP::Decompressor#handle_response
DEBUG: Chef::HTTP calling Chef::HTTP::CookieManager#handle_response
DEBUG: Chef::HTTP calling Chef::HTTP::JSONOutput#handle_response
DEBUG: Expected JSON response, but got content-type ''
DEBUG: Chef::HTTP calling Chef::HTTP::JSONInput#handle_response
INFO: HTTP Request Returned 404 Object Not Found: error
DEBUG: Chef::HTTP calling Chef::HTTP::JSONInput#handle_response
INFO: HTTP Request Returned 404 Object Not Found: error
/opt/opscode/embedded/lib/ruby/gems/2.2.0/gems/chef-12.19.36/lib/chef/chef_fs/file_system/chef_server/rest_list_entry.rb:110:in `rescue in _read_json': Chef::ChefFS::FileSystem::NotFoundError (Chef::ChefFS::FileSystem::NotFoundError)
        from /opt/opscode/embedded/lib/ruby/gems/2.2.0/gems/chef-12.19.36/lib/chef/chef_fs/file_system/chef_server/rest_list_entry.rb:105:in `_read_json'
        from /opt/opscode/embedded/lib/ruby/gems/2.2.0/gems/chef-12.19.36/lib/chef/chef_fs/file_system/chef_server/rest_list_entry.rb:100:in `read'
        from /opt/opscode/embedded/lib/ruby/gems/2.2.0/gems/chef-12.19.36/lib/chef/chef_fs/file_system.rb:331:in `copy_entries'
        from /opt/opscode/embedded/lib/ruby/gems/2.2.0/gems/chef-12.19.36/lib/chef/chef_fs/file_system.rb:143:in `block in copy_to'
        from /opt/opscode/embedded/lib/ruby/gems/2.2.0/gems/chef-12.19.36/lib/chef/chef_fs/parallelizer/parallel_enumerable.rb:263:in `call'
        from /opt/opscode/embedded/lib/ruby/gems/2.2.0/gems/chef-12.19.36/lib/chef/chef_fs/parallelizer/parallel_enumerable.rb:263:in `process_input'
        from /opt/opscode/embedded/lib/ruby/gems/2.2.0/gems/chef-12.19.36/lib/chef/chef_fs/parallelizer/parallel_enumerable.rb:253:in `process_one'
        from /opt/opscode/embedded/lib/ruby/gems/2.2.0/gems/chef-12.19.36/lib/chef/chef_fs/parallelizer.rb:92:in `call'
        from /opt/opscode/embedded/lib/ruby/gems/2.2.0/gems/chef-12.19.36/lib/chef/chef_fs/parallelizer.rb:92:in `worker_loop'
```

Because of:
https://github.com/chef/chef/blob/master/lib/chef/chef_fs/file_system/chef_server/rest_list_entry.rb#L113

It's a `Net::HTTPServerException` that gets rescued and re-raised as a `Chef::ChefFS::FileSystem::NotFoundError`. 

This PR simply adds a rescue for `Chef::ChefFS::FileSystem::NotFoundError` and `Chef::ChefFS::FileSystem::OperationFailedError` and adds the exception to our `knife_ec_error_handler`

Signed-off-by: Jeremy J. Miller <jm@chef.io>