### PR TITLE
[SUSTAIN-657] Handle and report user restore fails

### DIFF
--- a/lib/chef/knife/ec_key_import.rb
+++ b/lib/chef/knife/ec_key_import.rb
@@ -25,7 +25,6 @@ class Chef
     class EcKeyImport < Chef::Knife
 
       include Knife::EcKeyBase
-      include Knife::EcBase
 
       banner "knife ec key import [USER_DATA_PATH] [KEY_DATA_PATH]"
 
@@ -166,6 +165,7 @@ class Chef
 
       def import_user_data(path)
         key_data = JSON.parse(File.read(path))
+        knife_ec_error_handler = config[:knife_ec_error_handler]
         key_data.each do |d|
           if d['username'] == 'pivotal' && config[:skip_pivotal]
             ui.warn "Skipping pivotal user."
@@ -200,7 +200,7 @@ class Chef
                 ui.warn message
                 ex = ex.exception "#{ex.message} #{message}"
               end
-              knife_ec_error_handler.add(ex)
+              knife_ec_error_handler.add(ex) if knife_ec_error_handler
             end
           end
         end

--- a/lib/chef/knife/ec_restore.rb
+++ b/lib/chef/knife/ec_restore.rb
@@ -186,6 +186,7 @@ class Chef
 
       def restore_user_sql
         k = ec_key_import
+        k.config[:knife_ec_error_handler] = knife_ec_error_handler
         k.config[:skip_users_table] = false
         k.config[:skip_keys_table] = !config[:with_key_sql]
         k.config[:users_only] = true


### PR DESCRIPTION
Currently, importing user data on a restore can fail with a less than
optimal error message, and kill the restore altogether.

This change rescues these failures, adds some color to the exception
message about the probable cause, and adds them the error collection to
be reported at the end of the run.

Signed-off-by: Nolan Davidson <ndavidson@chef.io>