### PR TITLE
support server version when habitat

### DIFF
--- a/lib/chef/server.rb
+++ b/lib/chef/server.rb
@@ -15,13 +15,17 @@ class Chef
       Chef::Server.new(url)
     end
 
+    def parse_server_version(line)
+      # first line from the /version endpoint will either be this format "chef-server 12.17.5\n"
+      # or, when habitat, this format "Package: chef-server/chef-server-nginx/12.17.42/20180413212943\n"
+      Gem::Version.new(line.include?('/') ? line.split('/')[2] : line.split(' ').last.gsub(/\+.*$/, ''))
+    end
+
     def version
       @version ||= begin
                      uri = URI.parse("#{root_url}/version")
                      ver_line = open(uri, {ssl_verify_mode: OpenSSL::SSL::VERIFY_NONE}).each_line.first
-                     ver_string = ver_line.split(' ').last
-                     ver_string = ver_string.gsub(/\+.*$/, '')
-                     Gem::Version.new(ver_string)
+                     parse_server_version(ver_line)
                    end
     end
 

--- a/spec/chef/server_spec.rb
+++ b/spec/chef/server_spec.rb
@@ -10,10 +10,16 @@ describe Chef::Server do
     expect(s.root_url).to eq("http://api.example.com")
   end
 
-  it "determines the server version" do
-    s = Chef::Server.new("http://api.example.com")
+  it "determines the running habitat service pkg version" do
+    s = Chef::Server.new('http://api.example.com')
+    allow(s).to receive(:open).and_return(StringIO.new("Package: chef-server/chef-server-nginx/12.17.42/20180413212943\nother stuff\nother stuff"))
+    expect(s.version.to_s).to eq('12.17.42')
+  end
+
+  it "determines the running omnibus server version" do
+    s = Chef::Server.new('http://api.example.com')
     allow(s).to receive(:open).and_return(StringIO.new("Chef Server 1.8.1\nother stuff\nother stuff"))
-    expect(s.version.to_s).to eq("1.8.1")
+    expect(s.version.to_s).to eq('1.8.1')
   end
 
   it "ignores git tags when determining the version" do
@@ -22,7 +28,7 @@ describe Chef::Server do
     expect(s.version.to_s).to eq("1.8.1")
   end
 
-  it "knows whether the server supports user ACLs via ngingx" do
+  it "knows whether the server supports user ACLs via nginx" do
     s1 = Chef::Server.new("http://api.example.com")
     s2 = Chef::Server.new("http://api.example.com")
     allow(s1).to receive(:open).and_return(StringIO.new("Chef Server 11.0.0\nother stuff\nother stuff"))


### PR DESCRIPTION
### :nut_and_bolt: Description
This PR adds support for parsing the Server version when the server is running as a Habitat service.

![18171698](https://user-images.githubusercontent.com/1991696/39448868-fe8ba892-4c8b-11e8-815c-b6a57cfaa782.png)

### :white_check_mark: Checklist

- [x] Code actually executed?
- [x] Vetting performed (unit tests, lint, etc.)?

Signed-off-by: Jeremy J. Miller <jm@chef.io>