### PR TITLE
warn when clients group appears incorrect

### DIFF
--- a/lib/chef/knife/ec_backup.rb
+++ b/lib/chef/knife/ec_backup.rb
@@ -50,6 +50,8 @@ class Chef
           download_org_invitations(name)
         end
 
+        warn_on_incorrect_clients_group(dest_dir, "backup")
+
         completion_banner
       end
 

--- a/lib/chef/knife/ec_base.rb
+++ b/lib/chef/knife/ec_base.rb
@@ -234,8 +234,8 @@ class Chef
           existing_group_data = FFI_Yajl::Parser.parse(::File.read(clients_group_path), symbolize_names: false)
           existing_group_data['clients'] = [] unless existing_group_data.key?('clients')
           if existing_group_data['clients'].length != clients_in_org.length
-            ui.warn "There are #{(existing_group_data['clients'].length - clients_in_org.length).abs} missing clients in #{org}'s client group file #{clients_group_path}. If this is not intentional do not perform a restore until corrected. `knife tidy backup clean` will auto-correct this. https://github.com/chef-customers/knife-tidy"
-            ui.confirm("\nDo you wish to continue?") if op == "restore"
+            ui.warn "There are #{(existing_group_data['clients'].length - clients_in_org.length).abs} missing clients in #{org}'s client group file #{clients_group_path}. If this is not intentional do NOT proceed with a restore until corrected. `knife tidy backup clean` will auto-correct this. https://github.com/chef-customers/knife-tidy"
+            ui.confirm("\nDo you still wish to continue with the restore?") if op == "restore"
           end
         end
       end

--- a/lib/chef/knife/ec_base.rb
+++ b/lib/chef/knife/ec_base.rb
@@ -20,6 +20,7 @@ require 'chef/knife'
 require 'chef/server_api'
 require 'veil'
 require 'chef/knife/ec_error_handler'
+require 'ffi_yajl'
 
 class Chef
   class Knife
@@ -221,6 +222,21 @@ class Chef
         if !File.exist?(webui_key)
           ui.error("Webui Key (#{config[:webui_key]}) does not exist.")
           exit 1
+        end
+      end
+
+      def warn_on_incorrect_clients_group(dir, op)
+        orgs = Dir[::File.join(dir, 'organizations', '*')].map { |d| ::File.basename(d) }
+        orgs.each do |org|
+          clients_path = ::File.expand_path(::File.join(dir, 'organizations', org, 'clients'))
+          clients_in_org = Dir[::File.join(clients_path, '*')].map { |d| ::File.basename(d, '.json') }
+          clients_group_path = ::File.expand_path(::File.join(dir, 'organizations', org, 'groups', 'clients.json'))
+          existing_group_data = FFI_Yajl::Parser.parse(::File.read(clients_group_path), symbolize_names: false)
+          existing_group_data['clients'] = [] unless existing_group_data.key?('clients')
+          if existing_group_data['clients'].length != clients_in_org.length
+            ui.warn "There are #{(existing_group_data['clients'].length - clients_in_org.length).abs} missing clients in #{org}'s client group file #{clients_group_path}. If this is not intentional do not perform a restore until corrected. `knife tidy backup clean` will auto-correct this. https://github.com/chef-customers/knife-tidy"
+            ui.confirm("\nDo you wish to continue?") if op == "restore"
+          end
         end
       end
 

--- a/lib/chef/knife/ec_restore.rb
+++ b/lib/chef/knife/ec_restore.rb
@@ -39,6 +39,8 @@ class Chef
         ensure_webui_key_exists!
         set_skip_user_acl!
 
+        warn_on_incorrect_clients_group(dest_dir, "restore")
+
         restore_users unless config[:skip_users]
         restore_user_sql if config[:with_user_sql]
 


### PR DESCRIPTION
## Description

This PR adds detection and a WARN message when any org's clients group either:
 * has no clients (Array) key
 * does not have all the clients that are in the org

## Background
oc_erchef has a timeout for oc_chef_authz connections that defaults to 2000ms.
For organizations with thousands of clients, this timeout can be exceeded when querying the `clients` group. The resulting timeout aborts the query for hydrating the clients group, however the timeout is masked from the end user. Erchef does not return an error but actually an **empty** clients group. All this is happens while the client side user is left in the dark.

When the user goes to restore the ec backup they restore an empty clients group causing all sorts of authorization issues.

Full details of the Chef Server issue https://github.com/chef/chef-server/issues/1499

## Assumption
This PR assumes that the intention and correct behavior is that the clients group has ALL clients from the organization as members.

The ux looks like:

backup
```
Copying /groups/admins.json
Copying /groups/clients.json
Copying /groups/users.json
WARNING: There are 12537 missing clients in brewinc's client group file /Users/jmiller/Devel/ChefProject/chef-server-vagrant/backups/organizations/brewinc/groups/clients.json. If this is not intentional do NOT perform a restore until corrected. `knife tidy backup clean` will auto-correct this. https://github.com/chef-customers/knife-tidy
** Finished **
```

restore
```
WARNING: There are 12537 missing clients in brewinc's client group file /Users/jmiller/Devel/ChefProject/chef-server-vagrant/backups/organizations/brewinc/groups/clients.json. If this is not intentional do NOT perform a restore until corrected. `knife tidy backup clean` will auto-correct this. https://github.com/chef-customers/knife-tidy

Do you still wish to continue with the restore?? (Y/N)
```

## Notes
 Ideally `knife-ec-backup` handles the auto correction as well.
I think this can be more or less easily achieved when we add the functionality of `knife-tidy` into `knife-ec-backup` - we all agreed this was our intended direction, amirite? 🙂 

Signed-off-by: Jeremy J. Miller <jm@chef.io>