### PR TITLE
Default skip_ids to true when restoring with sql options.

### DIFF
--- a/README.md
+++ b/README.md
@@ -230,6 +230,10 @@ Private Chef server. DEST_DIR should be a backup directory created by
     Skip Chef Server version check. This will
     also skip any auto-configured options (default: false)
 
+  * `--[no-]skip-user-ids`:
+    Reuses user ids from the restore destination when updating existing 
+    users to avoid database conflicts (default: true)
+
   * `--with-user-sql`:
     Whether to backup/restore user data directly from the database.  This
     requires access to the listening postgresql port on the Chef

--- a/lib/chef/knife/ec_key_import.rb
+++ b/lib/chef/knife/ec_key_import.rb
@@ -38,7 +38,7 @@ class Chef
         :long => "--[no-]skip-user-ids",
         :default => true,
         :boolean => true,
-        :description => "Upload user ids."
+        :description => "Reuses user ids from the restore destination when updating existing users to avoid database conflicts."
 
       option :users_only,
         :long => "--users-only",

--- a/lib/chef/knife/ec_restore.rb
+++ b/lib/chef/knife/ec_restore.rb
@@ -177,7 +177,7 @@ class Chef
                              k = Chef::Knife::EcKeyImport.new
                              k.name_args = ["#{dest_dir}/key_dump.json", "#{dest_dir}/key_table_dump.json"]
                              k.config[:skip_pivotal] = true
-                             k.config[:skip_ids] = false
+                             k.config[:skip_ids] = true
                              k.config[:sql_host] = config[:sql_host]
                              k.config[:sql_port] = config[:sql_port]
                              k.config[:sql_user] = config[:sql_user]

--- a/lib/chef/knife/ec_restore.rb
+++ b/lib/chef/knife/ec_restore.rb
@@ -23,7 +23,7 @@ class Chef
         :long => "--[no-]skip-user-ids",
         :default => true,
         :boolean => true,
-        :description => "Upload user ids."
+        :description => "Reuses user ids from the restore destination when updating existing users to avoid database conflicts."
 
       deps do
         require 'chef/json_compat'

--- a/lib/chef/knife/ec_restore.rb
+++ b/lib/chef/knife/ec_restore.rb
@@ -19,6 +19,12 @@ class Chef
         :long => "--skip-users",
         :description => "Skip restoring users"
 
+      option :skip_ids,
+        :long => "--[no-]skip-user-ids",
+        :default => true,
+        :boolean => true,
+        :description => "Upload user ids."
+
       deps do
         require 'chef/json_compat'
         require 'chef/chef_fs/config'
@@ -177,7 +183,7 @@ class Chef
                              k = Chef::Knife::EcKeyImport.new
                              k.name_args = ["#{dest_dir}/key_dump.json", "#{dest_dir}/key_table_dump.json"]
                              k.config[:skip_pivotal] = true
-                             k.config[:skip_ids] = true
+                             k.config[:skip_ids] = config[:skip_ids]
                              k.config[:sql_host] = config[:sql_host]
                              k.config[:sql_port] = config[:sql_port]
                              k.config[:sql_user] = config[:sql_user]

--- a/lib/knife_ec_backup/version.rb
+++ b/lib/knife_ec_backup/version.rb
@@ -1,3 +1,3 @@
 module KnifeECBackup
-  VERSION = '2.3.0'
+  VERSION = '2.4.0'
 end


### PR DESCRIPTION
This will allow re-using user primary keys when updating users already in the db. This effectively adds support for merging multiple chef server data sets on top of each other.

Signed-off-by: Josh Hudson <jhudson@chef.io>