### PR TITLE
enable backup/restore via Chef Automate Chef Server API

### DIFF
--- a/README.md
+++ b/README.md
@@ -96,6 +96,10 @@ The following options are supported across all subcommands:
   * `--sql-port`:
     The postgresql listening port on the Chef Server. (default: 5432)
 
+  * `--sql-db`:
+    The postgresql Chef Server database name. (default: opscode_chef)
+    Specify 'automate-cs-oc-erchef' when using Automate Chef Server API
+
   * `--sql-user`:
     The username of postgresql user with access to the opscode_chef
     database. (default: autoconfigured from

--- a/lib/chef/knife/ec_backup.rb
+++ b/lib/chef/knife/ec_backup.rb
@@ -133,6 +133,7 @@ class Chef
         k.name_args = ["#{dest_dir}/key_dump.json", "#{dest_dir}/key_table_dump.json"]
         k.config[:sql_host] = config[:sql_host]
         k.config[:sql_port] = config[:sql_port]
+        k.config[:sql_db] = config[:sql_db]
         k.config[:sql_user] = config[:sql_user]
         k.config[:sql_password] = config[:sql_password]
         k.config[:skip_users_table] = !config[:with_user_sql]

--- a/lib/chef/knife/ec_base.rb
+++ b/lib/chef/knife/ec_base.rb
@@ -70,6 +70,11 @@ class Chef
             :description => 'Postgresql database port (default: 5432)',
             :default => 5432
 
+          option :sql_db,
+            :long => '--sql-db DBNAME',
+            :description => 'Postgresql Chef Server database name (default: opscode_chef)',
+            :default => "opscode_chef"
+
           option :sql_user,
             :long => "--sql-user USERNAME",
             :description => 'User used to connect to the postgresql database.'

--- a/lib/chef/knife/ec_key_base.rb
+++ b/lib/chef/knife/ec_key_base.rb
@@ -40,6 +40,11 @@ class Chef
           :description => 'Postgresql database port (default: 5432)',
           :default => 5432
 
+          option :sql_db,
+          :long => '--sql-db DBNAME',
+          :description => 'Postgresql Chef Server database name (default: opscode_chef)',
+          :default => "opscode_chef"
+
           option :sql_user,
           :long => "--sql-user USERNAME",
           :description => 'User used to connect to the postgresql database.'
@@ -68,7 +73,7 @@ class Chef
       def db
         @db ||= begin
                   require 'sequel'
-                  server_string = "#{config[:sql_user]}:#{config[:sql_password]}@#{config[:sql_host]}:#{config[:sql_port]}/opscode_chef"
+                  server_string = "#{config[:sql_user]}:#{config[:sql_password]}@#{config[:sql_host]}:#{config[:sql_port]}/#{config[:sql_db]}"
                   ::Sequel.connect("postgres://#{server_string}", :convert_infinite_timestamps => :string)
                 end
       end

--- a/lib/chef/knife/ec_restore.rb
+++ b/lib/chef/knife/ec_restore.rb
@@ -186,6 +186,7 @@ class Chef
                              k.config[:skip_ids] = config[:skip_ids]
                              k.config[:sql_host] = config[:sql_host]
                              k.config[:sql_port] = config[:sql_port]
+                             k.config[:sql_db] = config[:sql_db]
                              k.config[:sql_user] = config[:sql_user]
                              k.config[:sql_password] = config[:sql_password]
                              k

--- a/lib/chef/server.rb
+++ b/lib/chef/server.rb
@@ -23,8 +23,7 @@ class Chef
 
     def version
       @version ||= begin
-                     uri = URI.parse("#{root_url}/version")
-                     ver_line = open(uri, {ssl_verify_mode: OpenSSL::SSL::VERIFY_NONE}).each_line.first
+                     ver_line = Chef::ServerAPI.new(root_url).get('version').each_line.first
                      parse_server_version(ver_line)
                    end
     end

--- a/spec/chef/server_spec.rb
+++ b/spec/chef/server_spec.rb
@@ -22,8 +22,8 @@ describe Chef::Server do
 
   it "determines the running Automate CS API habitat service pkg version" do
     s = Chef::Server.new('http://api.example.com')
-    allow(@rest).to receive(:get).with("version").and_return(StringIO.new("Package: chef-server/chef-server-nginx/12.17.42/20180413212943\nother stuff\nother stuff"))
-    expect(s.version.to_s).to eq('12.17.42')
+    allow(@rest).to receive(:get).with("version").and_return(StringIO.new("Package: chef/automate-cs-nginx/12.19.31/20190529200833\nHabitat: 0.69.0/20181127183841\nMember: f73decd1025f4a5aa728b4429c297ef1 / ip-10-1-1-200.us-west-1.compute.internal"))
+    expect(s.version.to_s).to eq('12.19.31')
   end
 
   it "determines the running omnibus server version" do


### PR DESCRIPTION
Signed-off-by: Jeremy J. Miller <jm@chef.io>

### Description
With the following changes, this PR allows backup/restores of the Chef Server API that is integrated into Chef Automate.
- use Chef::ServerAPI to properly sign the GET request of `/version`
- allow users to specify a custom Erchef DB name (it's 'automate-cs-oc-erchef' when using Automate Chef Server API)

### Check List

- [x] New functionality includes tests
- [x] All tests pass
- [x] All commits have been signed-off for the Developer Certificate of Origin. See <https://github.com/chef/chef/blob/master/CONTRIBUTING.md#developer-certification-of-origin-dco>
- [x] PR title is a worthy inclusion in the CHANGELOG