### PR TITLE
Substitute require for require_relative

### DIFF
--- a/lib/chef/knife/ec_backup.rb
+++ b/lib/chef/knife/ec_backup.rb
@@ -1,5 +1,5 @@
 require 'chef/knife'
-require 'chef/knife/ec_base'
+require_relative 'ec_base'
 
 class Chef
   class Knife
@@ -14,7 +14,7 @@ class Chef
         require 'chef/chef_fs/file_system'
         require 'chef/chef_fs/file_pattern'
         require 'chef/chef_fs/parallelizer'
-        require 'chef/server'
+        require_relative '../server'
         require 'fileutils'
       end
 
@@ -127,7 +127,7 @@ class Chef
       end
 
       def export_from_sql
-        require 'chef/knife/ec_key_export'
+        require_relative 'ec_key_export'
         Chef::Knife::EcKeyExport.deps
         k = Chef::Knife::EcKeyExport.new
         k.name_args = ["#{dest_dir}/key_dump.json", "#{dest_dir}/key_table_dump.json"]

--- a/lib/chef/knife/ec_base.rb
+++ b/lib/chef/knife/ec_base.rb
@@ -19,7 +19,7 @@
 require 'chef/knife'
 require 'chef/server_api'
 require 'veil'
-require 'chef/knife/ec_error_handler'
+require_relative 'ec_error_handler'
 require 'ffi_yajl'
 
 class Chef

--- a/lib/chef/knife/ec_key_export.rb
+++ b/lib/chef/knife/ec_key_export.rb
@@ -17,7 +17,7 @@
 #
 
 require 'chef/knife'
-require 'chef/knife/ec_key_base'
+require_relative 'ec_key_base'
 
 class Chef
   class Knife

--- a/lib/chef/knife/ec_key_import.rb
+++ b/lib/chef/knife/ec_key_import.rb
@@ -17,8 +17,8 @@
 #
 
 require 'chef/knife'
-require 'chef/knife/ec_key_base'
-require 'chef/org_id_cache'
+require_relative 'ec_key_base'
+require_relative '../org_id_cache'
 
 class Chef
   class Knife

--- a/lib/chef/knife/ec_restore.rb
+++ b/lib/chef/knife/ec_restore.rb
@@ -1,5 +1,5 @@
 require 'chef/knife'
-require 'chef/knife/ec_base'
+require_relative 'ec_base'
 
 class Chef
   class Knife
@@ -35,8 +35,8 @@ class Chef
         require 'chef/chef_fs/data_handler/acl_data_handler'
         require 'securerandom'
         require 'chef/chef_fs/parallelizer'
-        require 'chef/tsorter'
-        require 'chef/server'
+        require_relative '../tsorter'
+        require_relative '../server'
       end
 
       def run
@@ -179,7 +179,7 @@ class Chef
 
       def ec_key_import
         @ec_key_import ||= begin
-                             require 'chef/knife/ec_key_import'
+                             require_relative 'ec_key_import'
                              k = Chef::Knife::EcKeyImport.new
                              k.name_args = ["#{dest_dir}/key_dump.json", "#{dest_dir}/key_table_dump.json"]
                              k.config[:skip_pivotal] = true


### PR DESCRIPTION
require_relative is significantly faster and should be used when available.

Signed-off-by: Tim Smith <tsmith@chef.io>