### PR TITLE
ability to log errors in separate directory

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -16,6 +16,9 @@ group :development do
   gem 'rake'
   gem 'simplecov'
   gem 'fakefs'
+  if Gem::Version.new(RUBY_VERSION) < Gem::Version.new("2.5")
+    gem "chef", "~> 14"
+  end
   if Gem::Version.new(RUBY_VERSION) < Gem::Version.new("2.6")
     gem "chef-zero", "~> 14"
   end

--- a/Gemfile
+++ b/Gemfile
@@ -16,6 +16,9 @@ group :development do
   gem 'rake'
   gem 'simplecov'
   gem 'fakefs'
+  if Gem::Version.new(RUBY_VERSION) < Gem::Version.new("2.6")
+    gem "chef-zero", "~> 14"
+  end
 end
 
 # This is here instead of gemspec so that we can

--- a/lib/chef/knife/ec_base.rb
+++ b/lib/chef/knife/ec_base.rb
@@ -31,6 +31,10 @@ class Chef
       def self.included(includer)
         includer.class_eval do
 
+          option :error_log_dir,
+            :long => '--error-log-dir PATH',
+            :description => 'Path to a directory where any errors will be logged'
+
           option :concurrency,
             :long => '--concurrency THREADS',
             :description => 'Maximum number of simultaneous requests to send (default: 10)'
@@ -160,7 +164,8 @@ class Chef
       end
 
       def knife_ec_error_handler
-        @knife_ec_error_handler ||= Chef::Knife::EcErrorHandler.new(dest_dir, self.class)
+        error_dir = !config[:error_log_dir].nil? ? config[:error_log_dir] : dest_dir
+        @knife_ec_error_handler ||= Chef::Knife::EcErrorHandler.new(error_dir, self.class)
       end
 
       def user_acl_rest

--- a/lib/chef/knife/ec_base.rb
+++ b/lib/chef/knife/ec_base.rb
@@ -164,7 +164,7 @@ class Chef
       end
 
       def knife_ec_error_handler
-        error_dir = !config[:error_log_dir].nil? ? config[:error_log_dir] : dest_dir
+        error_dir = config[:error_log_dir] || dest_dir
         @knife_ec_error_handler ||= Chef::Knife::EcErrorHandler.new(error_dir, self.class)
       end
 

--- a/spec/chef/knife/ec_key_base_spec.rb
+++ b/spec/chef/knife/ec_key_base_spec.rb
@@ -6,7 +6,7 @@ class KeyBaseTester < Chef::Knife
 end
 
 describe Chef::Knife::EcKeyBase do
-  let (:knife) { Chef::Knife::KeyBaseTester.new }
+  let (:knife) { KeyBaseTester.new }
 
   let(:running_server_postgresql_sql_config_json) {
     '{"private_chef": { "opscode-erchef":{}, "postgresql": { "sql_user": "jiminy", "sql_password": "secret"} }, "postgresql": { "sql_user": "jiminy", "sql_password": "secret"} }'
@@ -35,4 +35,3 @@ describe Chef::Knife::EcKeyBase do
     end
   end
 end
-


### PR DESCRIPTION
This allows users to define a distinct path for where any errors from the exception handler will be logged.

**Use case:** An organization performing a restore to their DR Chef Server from a read-only NAS share. With this change they can pass `--error-log-dir  /some/writable/path`. Previously, if any exceptions were encountered, the restore would fail with a filesystem permission denied error when attempting to log the error.

Signed-off-by: Jeremy J. Miller <jm@chef.io>
