### PR TITLE
Fix the tests

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -16,11 +16,9 @@ group :development do
   gem 'rake'
   gem 'simplecov'
   gem 'fakefs'
-  if Gem::Version.new(RUBY_VERSION) < Gem::Version.new("2.5")
-    gem "chef", "~> 14"
-  end
   if Gem::Version.new(RUBY_VERSION) < Gem::Version.new("2.6")
     gem "chef-zero", "~> 14"
+    gem "chef", "~> 14"
   end
 end
 


### PR DESCRIPTION
ruby 2.5 was pulling in the latest chef which requires >= ruby 2.6