### PR TITLE
Optimize our requires

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -1,5 +1,5 @@
 require 'bundler'
-require 'rubygems'
+require 'rubygems' unless defined?(Gem)
 require 'rubygems/package_task'
 require 'rdoc/task'
 require 'rspec/core/rake_task'

--- a/lib/chef/knife/ec_backup.rb
+++ b/lib/chef/knife/ec_backup.rb
@@ -15,7 +15,7 @@ class Chef
         require 'chef/chef_fs/file_pattern'
         require 'chef/chef_fs/parallelizer'
         require_relative '../server'
-        require 'fileutils'
+        require 'fileutils' unless defined?(FileUtils)
       end
 
       def run

--- a/lib/chef/knife/ec_base.rb
+++ b/lib/chef/knife/ec_base.rb
@@ -20,7 +20,7 @@ require 'chef/knife'
 require 'chef/server_api'
 require 'veil'
 require_relative 'ec_error_handler'
-require 'ffi_yajl'
+require 'ffi_yajl' unless defined?(FFI_Yajl)
 
 class Chef
   class Knife

--- a/lib/chef/knife/ec_key_base.rb
+++ b/lib/chef/knife/ec_key_base.rb
@@ -27,7 +27,7 @@ class Chef
 
           deps do
             require 'sequel'
-            require 'json'
+            require 'json' unless defined?(JSON)
           end
 
           option :sql_host,

--- a/lib/chef/knife/ec_restore.rb
+++ b/lib/chef/knife/ec_restore.rb
@@ -33,7 +33,7 @@ class Chef
         # Work around bug in chef_fs
         require 'chef/chef_fs/command_line'
         require 'chef/chef_fs/data_handler/acl_data_handler'
-        require 'securerandom'
+        require 'securerandom' unless defined?(SecureRandom)
         require 'chef/chef_fs/parallelizer'
         require_relative '../tsorter'
         require_relative '../server'

--- a/lib/chef/server.rb
+++ b/lib/chef/server.rb
@@ -1,5 +1,5 @@
-require 'uri'
-require 'openssl'
+require 'uri' unless defined?(URI)
+require 'openssl' unless defined?(OpenSSL)
 require 'chef/server_api'
 
 class Chef

--- a/spec/chef/knife/ec_base_spec.rb
+++ b/spec/chef/knife/ec_base_spec.rb
@@ -2,7 +2,7 @@ require File.expand_path(File.join(File.dirname(__FILE__), "..", "..", "spec_hel
 require 'chef/knife/ec_base'
 require 'chef/knife'
 require 'chef/config'
-require 'stringio'
+require 'stringio' unless defined?(StringIO)
 
 class Tester < Chef::Knife
   include Chef::Knife::EcBase

--- a/spec/chef/knife/ec_key_export_spec.rb
+++ b/spec/chef/knife/ec_key_export_spec.rb
@@ -1,8 +1,8 @@
 require File.expand_path(File.join(File.dirname(__FILE__), "..", "..", "spec_helper"))
 require 'chef/knife/ec_key_export'
 require 'sequel'
-require 'json'
-require 'securerandom'
+require 'json' unless defined?(JSON)
+require 'securerandom' unless defined?(SecureRandom)
 require 'fakefs/spec_helpers'
 
 def user_record(name)

--- a/spec/chef/server_spec.rb
+++ b/spec/chef/server_spec.rb
@@ -1,7 +1,7 @@
 require File.expand_path(File.join(File.dirname(__FILE__), "..", "spec_helper"))
 require 'chef/server'
 require 'chef/server_api'
-require 'stringio'
+require 'stringio' unless defined?(StringIO)
 
 describe Chef::Server do
   before(:each) do


### PR DESCRIPTION
Avoid requiring things that are already defined. Rubygems is very slow at traversing the filesystem.

Signed-off-by: Tim Smith <tsmith@chef.io>