### PR TITLE
Require Ruby 2.6 or later

### DIFF
--- a/.expeditor/verify.pipeline.yml
+++ b/.expeditor/verify.pipeline.yml
@@ -6,22 +6,6 @@ expeditor:
 
 steps:
 
-- label: run-lint-and-specs-ruby-2.4
-  command:
-    - .expeditor/run_linux_tests.sh rake
-  expeditor:
-    executor:
-      docker:
-        image: ruby:2.4-buster
-
-- label: run-lint-and-specs-ruby-2.5
-  command:
-    - .expeditor/run_linux_tests.sh rake
-  expeditor:
-    executor:
-      docker:
-        image: ruby:2.5-buster
-
 - label: run-lint-and-specs-ruby-2.6
   command:
     - .expeditor/run_linux_tests.sh rake

--- a/knife-ec-backup.gemspec
+++ b/knife-ec-backup.gemspec
@@ -13,6 +13,8 @@ Gem::Specification.new do |s|
   s.email = "jkeiser@chef.io"
   s.homepage = "https://www.chef.io"
 
+  s.required_ruby_version = ">= 2.6"
+
   # We need a more recent version of mixlib-cli in order to support --no- options.
   # ... but, we can live with those options not working, if it means the plugin
   # can be included with apps that have restrictive Gemfile.locks.


### PR DESCRIPTION
2.4 and 2.5 are EOL

Signed-off-by: Tim Smith <tsmith@chef.io>