### PR TITLE
Fix uninitialized constant Net::HTTPServerException

### DIFF
--- a/spec/chef/knife/ec_restore_spec.rb
+++ b/spec/chef/knife/ec_restore_spec.rb
@@ -3,6 +3,7 @@ require 'chef/knife/ec_restore'
 require 'fakefs/spec_helpers'
 require_relative './ec_error_handler_spec'
 require "chef/chef_fs/file_system/repository/chef_repository_file_system_root_dir"
+require 'net/http'
 
 def make_user(username)
   FileUtils.mkdir_p("/users")


### PR DESCRIPTION
error:
```
  1) Chef::Knife::EcErrorHandler #display
     Failure/Error: Net::HTTPServerException.new("I'm not real!", s)

     NameError:
       uninitialized constant Net::HTTPServerException
     # ./spec/chef/knife/ec_restore_spec.rb:20:in `net_exception'
     # ./spec/chef/knife/ec_error_handler_spec.rb:51:in `block (2
levels) in <top (required)>'
```
fix:
```
irb(main):005:0> require'net/http'
=> true
irb(main):006:0> Net::HTTPServerException
(irb):6: warning: constant Net::HTTPServerException is deprecated
=> Net::HTTPServerException
```
## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Chore (non-breaking change that does not add functionality or fix an issue)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have run the pre-merge tests locally and they pass.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
- [x] All commits have been signed-off for [the Developer Certificate of Origin](https://github.com/chef/chef/blob/master/CONTRIBUTING.md#developer-certification-of-origin-dco).
