### PR TITLE
Update branding to Chef Infra Server / remove mentions of enterprise

### DIFF
--- a/habitat/plan.sh
+++ b/habitat/plan.sh
@@ -1,7 +1,7 @@
 pkg_name=knife-ec-backup
 pkg_origin=chef
 pkg_maintainer="The Habitat Maintainers <humans@habitat.sh>"
-pkg_description="A knife plugin for backup/restore of Chef Server data."
+pkg_description="A knife plugin for backup/restore of Chef Infra Server data."
 pkg_upstream_url="https://github.com/chef/knife-ec-backup"
 pkg_license=('Apache-2.0')
 pkg_bin_dirs=(bin)

--- a/lib/chef/knife/ec_backup.rb
+++ b/lib/chef/knife/ec_backup.rb
@@ -34,7 +34,7 @@ class Chef
         for_each_user do |username, url|
           download_user(username, url)
           if config[:skip_useracl]
-            ui.warn("Skipping user ACL download for #{username}. To download this ACL, remove --skip-useracl or upgrade your Enterprise Chef Server.")
+            ui.warn("Skipping user ACL download for #{username}. To download this ACL, remove --skip-useracl.")
           else
             download_user_acl(username)
           end

--- a/lib/chef/knife/ec_base.rb
+++ b/lib/chef/knife/ec_base.rb
@@ -59,7 +59,7 @@ class Chef
             :long => '--skip-version-check',
             :boolean => true,
             :default => false,
-            :description => "Skip Chef Server version check.  This will also skip any auto-configured options"
+            :description => "Skip Chef Infra Server version check.  This will also skip any auto-configured options"
 
           option :org,
             :long => "--only-org ORG",
@@ -77,7 +77,7 @@ class Chef
 
           option :sql_db,
             :long => '--sql-db DBNAME',
-            :description => 'Postgresql Chef Server database name (default: opscode_chef or automate-cs-oc-erchef)'
+            :description => 'Postgresql Chef Infra Server database name (default: opscode_chef or automate-cs-oc-erchef)'
 
           option :sql_user,
             :long => "--sql-user USERNAME",

--- a/lib/chef/knife/ec_base.rb
+++ b/lib/chef/knife/ec_base.rb
@@ -67,17 +67,17 @@ class Chef
 
           option :sql_host,
             :long => '--sql-host HOSTNAME',
-            :description => 'Postgresql database hostname (default: localhost)',
+            :description => 'PostgreSQL database hostname (default: localhost)',
             :default => "localhost"
 
           option :sql_port,
             :long => '--sql-port PORT',
-            :description => 'Postgresql database port (default: 5432)',
+            :description => 'PostgreSQL database port (default: 5432)',
             :default => 5432
 
           option :sql_db,
             :long => '--sql-db DBNAME',
-            :description => 'Postgresql Chef Infra Server database name (default: opscode_chef or automate-cs-oc-erchef)'
+            :description => 'PostgreSQL Chef Infra Server database name (default: opscode_chef or automate-cs-oc-erchef)'
 
           option :sql_user,
             :long => "--sql-user USERNAME",

--- a/lib/chef/knife/ec_key_base.rb
+++ b/lib/chef/knife/ec_key_base.rb
@@ -34,17 +34,17 @@ class Chef
 
           option :sql_host,
           :long => '--sql-host HOSTNAME',
-          :description => 'Postgresql database hostname (default: localhost)',
+          :description => 'PostgreSQL database hostname (default: localhost)',
           :default => "localhost"
 
           option :sql_port,
           :long => '--sql-port PORT',
-          :description => 'Postgresql database port (default: 5432)',
+          :description => 'PostgreSQL database port (default: 5432)',
           :default => 5432
 
           option :sql_db,
           :long => '--sql-db DBNAME',
-          :description => 'Postgresql Chef Infra Server database name (default: opscode_chef or automate-cs-oc-erchef)'
+          :description => 'PostgreSQL Chef Infra Server database name (default: opscode_chef or automate-cs-oc-erchef)'
 
           option :sql_user,
           :long => "--sql-user USERNAME",

--- a/lib/chef/knife/ec_key_base.rb
+++ b/lib/chef/knife/ec_key_base.rb
@@ -44,7 +44,7 @@ class Chef
 
           option :sql_db,
           :long => '--sql-db DBNAME',
-          :description => 'Postgresql Chef Server database name (default: opscode_chef or automate-cs-oc-erchef)'
+          :description => 'Postgresql Chef Infra Server database name (default: opscode_chef or automate-cs-oc-erchef)'
 
           option :sql_user,
           :long => "--sql-user USERNAME",
@@ -114,7 +114,7 @@ class Chef
             exit 1
           else
             running_config ||= JSON.parse(File.read("/etc/opscode/chef-server-running.json"))
-            # Latest versions of chef server put the database info under opscode-erchef.sql_user
+            # Latest versions of Chef Infra Server put the database info under opscode-erchef.sql_user
             hash_key = if running_config['private_chef']['opscode-erchef'].has_key? 'sql_user'
                         'opscode-erchef'
                       else

--- a/lib/chef/knife/ec_key_export.rb
+++ b/lib/chef/knife/ec_key_export.rb
@@ -43,8 +43,8 @@ class Chef
           export_keys(key_data_path) unless config[:skip_keys_table]
         rescue Sequel::DatabaseError => e
           if e.message =~ /^PG::UndefinedTable/
-            ui.error "Keys table not found. The keys table only exists on Chef Server 12."
-            ui.error "Chef Server 11 users should use the --skip-keys-table option to avoid this error."
+            ui.error "Keys table not found. The keys table only exists on Chef Infra Server 12."
+            ui.error "Chef Infra Server 11 users should use the --skip-keys-table option to avoid this error."
             exit 1
           else
             raise

--- a/lib/chef/knife/ec_restore.rb
+++ b/lib/chef/knife/ec_restore.rb
@@ -65,7 +65,7 @@ class Chef
         restore_key_sql if config[:with_key_sql]
 
         if config[:skip_useracl]
-          ui.warn("Skipping user ACL update. To update user ACLs, remove --skip-useracl or upgrade your Enterprise Chef Server.")
+          ui.warn("Skipping user ACL update. To update user ACLs, remove --skip-useracl.")
         else
           restore_user_acls
         end
@@ -292,7 +292,7 @@ class Chef
           # Store organization data in a particular order:
           # - clients must be uploaded before groups (in top_level_paths)
           # - groups must be uploaded before any acl's
-          # - groups must be uploaded twice to account for Chef Server versions that don't
+          # - groups must be uploaded twice to account for Chef Infra Server versions that don't
           #   accept group members on POST
           (top_level_paths + group_paths*2 + group_acl_paths + acl_paths).each do |path|
             chef_fs_copy_pattern(path, chef_fs_config)
@@ -309,7 +309,7 @@ class Chef
       end
 
       # ChefFS copy pattern inside the EcRestore class will
-      # copy from the local_fs to the Chef Server.
+      # copy from the local_fs to the Chef Infra Server.
       #
       # NOTE: Do not get confused, this is the other way around
       # from how we implemented in EcBackup. Therefor we can't

--- a/spec/chef/knife/ec_backup_spec.rb
+++ b/spec/chef/knife/ec_backup_spec.rb
@@ -72,7 +72,7 @@ describe Chef::Knife::EcBackup do
       expect{ |b| @knife.for_each_organization(&b) }.to yield_successive_args(org_response("bar"), org_response("foo"))
     end
 
-    it "skips unassigned (precreated) organizations on Chef Server 11" do
+    it "skips unassigned (precreated) organizations on Chef Infra Server 11" do
       server = double('Chef::Server')
       allow(Chef::Server).to receive(:new).and_return(server)
       allow(server).to receive(:version).and_return(Gem::Version.new("11.12.3"))
@@ -81,7 +81,7 @@ describe Chef::Knife::EcBackup do
       expect{ |b| @knife.for_each_organization(&b) }.to yield_successive_args(org_response("bar"))
     end
 
-    it "includes *all* organizations on Chef Server 12" do
+    it "includes *all* organizations on Chef Infra Server 12" do
       server = double('Chef::Server')
       allow(Chef::Server).to receive(:new).and_return(server)
       allow(server).to receive(:version).and_return(Gem::Version.new("12.0.0"))

--- a/spec/chef/server_spec.rb
+++ b/spec/chef/server_spec.rb
@@ -9,7 +9,7 @@ describe Chef::Server do
     allow(Chef::ServerAPI).to receive(:new).and_return(@rest)
   end
 
-  it "infers root url from a Chef Server url" do
+  it "infers root url from a Chef Infra Server url" do
     s = Chef::Server.from_chef_server_url("http://api.example.com/organizations/foobar")
     expect(s.root_url).to eq("http://api.example.com")
   end
@@ -28,22 +28,22 @@ describe Chef::Server do
 
   it "determines the running omnibus server version" do
     s = Chef::Server.new('http://api.example.com')
-    allow(@rest).to receive(:get).with("version").and_return(StringIO.new("Chef Server 1.8.1\nother stuff\nother stuff"))
+    allow(@rest).to receive(:get).with("version").and_return(StringIO.new("Chef Infra Server 1.8.1\nother stuff\nother stuff"))
     expect(s.version.to_s).to eq('1.8.1')
   end
 
   it "ignores git tags when determining the version" do
     s = Chef::Server.new("http://api.example.com")
-    allow(@rest).to receive(:get).with("version").and_return(StringIO.new("Chef Server 1.8.1+20141024080718.git.16.08098a5\nother stuff\nother stuff"))
+    allow(@rest).to receive(:get).with("version").and_return(StringIO.new("Chef Infra Server 1.8.1+20141024080718.git.16.08098a5\nother stuff\nother stuff"))
     expect(s.version.to_s).to eq("1.8.1")
   end
 
   it "knows whether the server supports user ACLs via nginx" do
     s1 = Chef::Server.new("http://api.example.com")
-    allow(@rest).to receive(:get).with("version").and_return(StringIO.new("Chef Server 11.0.0\nother stuff\nother stuff"))
+    allow(@rest).to receive(:get).with("version").and_return(StringIO.new("Chef Infra Server 11.0.0\nother stuff\nother stuff"))
     expect(s1.supports_user_acls?).to eq(false)
     s2 = Chef::Server.new("http://api.example.com")
-    allow(@rest).to receive(:get).with("version").and_return(StringIO.new("Chef Server 11.0.2\nother stuff\nother stuff"))
+    allow(@rest).to receive(:get).with("version").and_return(StringIO.new("Chef Infra Server 11.0.2\nother stuff\nother stuff"))
     expect(s2.supports_user_acls?).to eq(true)
   end
 
@@ -61,10 +61,10 @@ describe Chef::Server do
 
   it "knows that public_key_read_access was implemented in 12.5.0" do
     before = Chef::Server.new("http://api.example.com")
-    allow(@rest).to receive(:get).with("version").and_return(StringIO.new("Chef Server 12.4.1\nother stuff\nother stuff"))
+    allow(@rest).to receive(:get).with("version").and_return(StringIO.new("Chef Infra Server 12.4.1\nother stuff\nother stuff"))
     expect(before.supports_public_key_read_access?).to eq(false)
     after = Chef::Server.new("http://api.example.com")
-    allow(@rest).to receive(:get).with("version").and_return(StringIO.new("Chef Server 12.6.0\nother stuff\nother stuff"))
+    allow(@rest).to receive(:get).with("version").and_return(StringIO.new("Chef Infra Server 12.6.0\nother stuff\nother stuff"))
     expect(after.supports_public_key_read_access?).to eq(true)
   end
 end


### PR DESCRIPTION
Remove support for ANCIENT Enterprise Chef.

Signed-off-by: Tim Smith <tsmith@chef.io>