### PR TITLE
Pass `--sql-db` to URI builder if given

### DIFF
--- a/lib/chef/knife/ec_key_base.rb
+++ b/lib/chef/knife/ec_key_base.rb
@@ -90,6 +90,9 @@ class Chef
                   server_uri = URI('postgres://')
                   server_uri.host = config[:sql_host]
                   server_uri.port = config[:sql_port]
+                  if config[:sql_db]
+                    server_uri.path = "/#{config[:sql_db]}"
+                  end
                   server_uri.user = URI.encode_www_form_component(config[:sql_user]) if config[:sql_user]
                   server_uri.password = URI.encode_www_form_component(config[:sql_password]) if config[:sql_password]
                   query_params = []


### PR DESCRIPTION
<!--- Provide a short summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail, what problems does it solve? -->
Previously `--sql-db` did not take effect as the db name was missing from the postgres URI.

## Related Issue
<!--- If you are suggesting a new feature or change, please create an issue first -->
<!--- Please link to the issue, discourse, or stackoverflow here: -->
https://github.com/chef/knife-ec-backup/issues/181

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Chore (non-breaking change that does not add functionality or fix an issue)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have read the **CONTRIBUTING** document.
- [x] I have run the pre-merge tests locally and they pass.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] If `Gemfile.lock` has changed, I have used `--conservative` to do it and included the full output in the Description above.
- [x] All new and existing tests passed.
- [x] All commits have been signed-off for [the Developer Certificate of Origin](https://github.com/chef/chef/blob/master/CONTRIBUTING.md#developer-certification-of-origin-dco). (obvious fix in this case)
