### PR TITLE
habitat: update to LTS-2024 channel and modernize dependencies

### DIFF
--- a/habitat/plan.sh
+++ b/habitat/plan.sh
@@ -1,3 +1,5 @@
+export HAB_BLDR_CHANNEL='LTS-2024'
+export HAB_REFRESH_CHANNEL="LTS-2024"
 pkg_name=knife-ec-backup
 pkg_origin=chef
 pkg_maintainer="The Habitat Maintainers <humans@habitat.sh>"
@@ -18,8 +20,8 @@ pkg_build_deps=(
 pkg_deps=(
   core/coreutils
   core/gcc
-  core/ruby31
-  core/postgresql-client
+  core/ruby3_1
+  core/postgresql13-client
   core/libffi
 )
 


### PR DESCRIPTION
- Add HAB_BLDR_CHANNEL and HAB_REFRESH_CHANNEL environment variables set to 'LTS-2024'
- Update Ruby dependency from core/ruby31 to core/ruby3_1 for consistency
- Update PostgreSQL client from core/postgresql-client to core/postgresql13-client

<!--- Provide a short summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail, what problems does it solve? -->

## Related Issue
<!--- If you are suggesting a new feature or change, please create an issue first -->
<!--- Please link to the issue, discourse, or stackoverflow here: -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Chore (non-breaking change that does not add functionality or fix an issue)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] I have read the **CONTRIBUTING** document.
- [ ] I have run the pre-merge tests locally and they pass.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] If `Gemfile.lock` has changed, I have used `--conservative` to do it and included the full output in the Description above.
- [ ] All new and existing tests passed.
- [ ] All commits have been signed-off for [the Developer Certificate of Origin](https://github.com/chef/chef/blob/master/CONTRIBUTING.md#developer-certification-of-origin-dco).
