### PR TITLE
CHEF-25781 - Standardize - Removing SLA from README

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,8 +2,6 @@
 [![Build status](https://badge.buildkite.com/4bc85427aab66accafbd7abb2932b9dd7f9208162c5be33488.svg?branch=main)](https://buildkite.com/chef-oss/chef-knife-ec-backup-main-verify)
 [![Gem Version](https://badge.fury.io/rb/knife-ec-backup.svg)](https://badge.fury.io/rb/knife-ec-backup)
 
-**Umbrella Project**: [Knife](https://github.com/chef/chef-oss-practices/blob/main/projects/knife.md)
-
 ## Description
 
 knife-ec-backup can backup and restore the data in a Chef Infra


### PR DESCRIPTION
This pull request removes the oft-misleading Chef SLA text from the README.md file.
This action is being taken as part of the [2025 Repo Standardization Initiative](https://github.com/chef-boneyard/oss-repo-standardization-2025). 
As Progress Chef makes a best effort to respond to issues and pull requests in a timely manner, and prioritizes bugfixes and security updates on a customer-driven basis (which may span repos, or have no repo footprint at all), we no longer support the concept of a Service Level Agreement (SLA) on a repository-centric basis. For further details, see [Repo SLA Removal FAQ](https://github.com/chef-boneyard/oss-repo-standardization-2025/blob/main/messaging/sla-removal.md).