### PR TITLE
Fix SSL params not forwarded to SQL subcommands

### DIFF
--- a/lib/chef/knife/ec_backup.rb
+++ b/lib/chef/knife/ec_backup.rb
@@ -143,6 +143,7 @@ class Chef
         k.config[:sql_cert] = config[:sql_cert]
         k.config[:sql_key] = config[:sql_key]
         k.config[:sql_rootcert] = config[:sql_rootcert]
+        k.config[:sql_sslmode] = config[:sql_sslmode]
         k.config[:skip_users_table] = !config[:with_user_sql]
         k.config[:skip_keys_table] = !config[:with_key_sql]
         k.run

--- a/lib/chef/knife/ec_backup.rb
+++ b/lib/chef/knife/ec_backup.rb
@@ -140,6 +140,9 @@ class Chef
         k.config[:sql_db] = config[:sql_db]
         k.config[:sql_user] = config[:sql_user]
         k.config[:sql_password] = config[:sql_password]
+        k.config[:sql_cert] = config[:sql_cert]
+        k.config[:sql_key] = config[:sql_key]
+        k.config[:sql_rootcert] = config[:sql_rootcert]
         k.config[:skip_users_table] = !config[:with_user_sql]
         k.config[:skip_keys_table] = !config[:with_key_sql]
         k.run

--- a/lib/chef/knife/ec_base.rb
+++ b/lib/chef/knife/ec_base.rb
@@ -88,7 +88,7 @@ class Chef
             :description => 'Password used to connect to the postgresql database'
 
           option :sql_cert,
-            :long => "--sql-cert ",
+            :long => "--sql-cert PATH",
             :description => 'Path to client ssl cert'
 
           option :sql_key,
@@ -96,8 +96,8 @@ class Chef
             :description => 'Path to client ssl key'
 
           option :sql_rootcert,
-          :long => "--sql-rootcert ",
-          :description => 'Path to root ssl cert'
+            :long => "--sql-rootcert PATH",
+            :description => 'Path to root ssl cert'
 
           option :with_user_sql,
             :long => '--with-user-sql',

--- a/lib/chef/knife/ec_base.rb
+++ b/lib/chef/knife/ec_base.rb
@@ -99,6 +99,10 @@ class Chef
             :long => "--sql-rootcert PATH",
             :description => 'Path to root ssl cert'
 
+          option :sql_sslmode,
+            :long => "--sql-sslmode SSLMODE",
+            :description => 'PostgreSQL SSL mode (disable, allow, prefer, require, verify-ca, verify-full). Default: prefer'
+
           option :with_user_sql,
             :long => '--with-user-sql',
             :description => 'Try direct data base access for user export/import.  Required to properly handle passwords, keys, and USAGs'

--- a/lib/chef/knife/ec_key_base.rb
+++ b/lib/chef/knife/ec_key_base.rb
@@ -55,7 +55,7 @@ class Chef
           :description => 'Password used to connect to the postgresql database'
 
           option :sql_cert,
-          :long => "--sql-cert ",
+          :long => "--sql-cert PATH",
           :description => 'Path to client ssl cert'
 
           option :sql_key,
@@ -63,7 +63,7 @@ class Chef
           :description => 'Path to client ssl key'
 
           option :sql_rootcert,
-          :long => "--sql-rootcert ",
+          :long => "--sql-rootcert PATH",
           :description => 'Path to root ssl cert'
 
           option :secrets_file_path,

--- a/lib/chef/knife/ec_key_base.rb
+++ b/lib/chef/knife/ec_key_base.rb
@@ -66,6 +66,10 @@ class Chef
           :long => "--sql-rootcert PATH",
           :description => 'Path to root ssl cert'
 
+          option :sql_sslmode,
+          :long => "--sql-sslmode SSLMODE",
+          :description => 'PostgreSQL SSL mode (disable, allow, prefer, require, verify-ca, verify-full). Default: prefer'
+
           option :secrets_file_path,
           :long => '--secrets-file PATH',
           :description => 'Path to a valid private-chef-secrets.json file (default: /etc/opscode/private-chef-secrets.json)',
@@ -96,6 +100,7 @@ class Chef
                   query_params.push("sslcert=#{config[:sql_cert]}") if config[:sql_cert]
                   query_params.push("sslkey=#{config[:sql_key]}") if config[:sql_key]
                   query_params.push("sslrootcert=#{config[:sql_rootcert]}") if config[:sql_rootcert]
+                  query_params.push("sslmode=#{config[:sql_sslmode]}") if config[:sql_sslmode]
                   server_uri.query = query_params.join("&") if query_params.length > 0
 
                   ::Sequel.connect(server_uri.to_s, :convert_infinite_timestamps => :string)

--- a/lib/chef/knife/ec_restore.rb
+++ b/lib/chef/knife/ec_restore.rb
@@ -193,6 +193,9 @@ class Chef
                              k.config[:sql_db] = config[:sql_db]
                              k.config[:sql_user] = config[:sql_user]
                              k.config[:sql_password] = config[:sql_password]
+                             k.config[:sql_cert] = config[:sql_cert]
+                             k.config[:sql_key] = config[:sql_key]
+                             k.config[:sql_rootcert] = config[:sql_rootcert]
                              k
                            end
       end

--- a/lib/chef/knife/ec_restore.rb
+++ b/lib/chef/knife/ec_restore.rb
@@ -196,6 +196,7 @@ class Chef
                              k.config[:sql_cert] = config[:sql_cert]
                              k.config[:sql_key] = config[:sql_key]
                              k.config[:sql_rootcert] = config[:sql_rootcert]
+                             k.config[:sql_sslmode] = config[:sql_sslmode]
                              k
                            end
       end

--- a/spec/chef/knife/ec_backup_spec.rb
+++ b/spec/chef/knife/ec_backup_spec.rb
@@ -277,6 +277,7 @@ describe Chef::Knife::EcBackup do
       @knife.config[:sql_cert]     = '/path/to/client.crt'
       @knife.config[:sql_key]      = '/path/to/client.key'
       @knife.config[:sql_rootcert] = '/path/to/ca.crt'
+      @knife.config[:sql_sslmode]  = 'verify-ca'
       @knife.config[:with_key_sql] = true
 
       exported_config = {}
@@ -287,6 +288,7 @@ describe Chef::Knife::EcBackup do
       expect(exported_config[:sql_cert]).to     eq('/path/to/client.crt')
       expect(exported_config[:sql_key]).to      eq('/path/to/client.key')
       expect(exported_config[:sql_rootcert]).to eq('/path/to/ca.crt')
+      expect(exported_config[:sql_sslmode]).to  eq('verify-ca')
     end
   end
 end

--- a/spec/chef/knife/ec_backup_spec.rb
+++ b/spec/chef/knife/ec_backup_spec.rb
@@ -260,4 +260,33 @@ describe Chef::Knife::EcBackup do
       end
     end
   end
+
+  describe "#export_from_sql" do
+    let(:key_export) { instance_double(Chef::Knife::EcKeyExport) }
+
+    before do
+      require 'chef/knife/ec_key_export'
+      allow(Chef::Knife::EcKeyExport).to receive(:deps)
+      allow(Chef::Knife::EcKeyExport).to receive(:new).and_return(key_export)
+      allow(key_export).to receive(:name_args=)
+      allow(key_export).to receive(:config).and_return({})
+      allow(key_export).to receive(:run)
+    end
+
+    it "forwards ssl cert, key, and rootcert config to EcKeyExport" do
+      @knife.config[:sql_cert]     = '/path/to/client.crt'
+      @knife.config[:sql_key]      = '/path/to/client.key'
+      @knife.config[:sql_rootcert] = '/path/to/ca.crt'
+      @knife.config[:with_key_sql] = true
+
+      exported_config = {}
+      allow(key_export).to receive(:config).and_return(exported_config)
+
+      @knife.export_from_sql
+
+      expect(exported_config[:sql_cert]).to     eq('/path/to/client.crt')
+      expect(exported_config[:sql_key]).to      eq('/path/to/client.key')
+      expect(exported_config[:sql_rootcert]).to eq('/path/to/ca.crt')
+    end
+  end
 end

--- a/spec/chef/knife/ec_restore_spec.rb
+++ b/spec/chef/knife/ec_restore_spec.rb
@@ -381,6 +381,7 @@ describe Chef::Knife::EcRestore do
       @knife.config[:sql_cert]     = '/path/to/client.crt'
       @knife.config[:sql_key]      = '/path/to/client.key'
       @knife.config[:sql_rootcert] = '/path/to/ca.crt'
+      @knife.config[:sql_sslmode]  = 'verify-ca'
       @knife.config[:sql_host]     = '127.0.0.1'
       @knife.config[:sql_port]     = 10145
       @knife.config[:sql_user]     = 'opscode_chef'
@@ -391,6 +392,7 @@ describe Chef::Knife::EcRestore do
       expect(k.config[:sql_cert]).to     eq('/path/to/client.crt')
       expect(k.config[:sql_key]).to      eq('/path/to/client.key')
       expect(k.config[:sql_rootcert]).to eq('/path/to/ca.crt')
+      expect(k.config[:sql_sslmode]).to  eq('verify-ca')
     end
   end
 end

--- a/spec/chef/knife/ec_restore_spec.rb
+++ b/spec/chef/knife/ec_restore_spec.rb
@@ -374,4 +374,23 @@ describe Chef::Knife::EcRestore do
       end
     end
   end
+
+  describe "#ec_key_import" do
+    it "forwards ssl cert, key, and rootcert config to EcKeyImport" do
+      require 'chef/knife/ec_key_import'
+      @knife.config[:sql_cert]     = '/path/to/client.crt'
+      @knife.config[:sql_key]      = '/path/to/client.key'
+      @knife.config[:sql_rootcert] = '/path/to/ca.crt'
+      @knife.config[:sql_host]     = '127.0.0.1'
+      @knife.config[:sql_port]     = 10145
+      @knife.config[:sql_user]     = 'opscode_chef'
+      @knife.config[:sql_password] = 'secret'
+
+      k = @knife.ec_key_import
+
+      expect(k.config[:sql_cert]).to     eq('/path/to/client.crt')
+      expect(k.config[:sql_key]).to      eq('/path/to/client.key')
+      expect(k.config[:sql_rootcert]).to eq('/path/to/ca.crt')
+    end
+  end
 end


### PR DESCRIPTION
Three bugs prevented SSL connections to PostgreSQL from working:

1. --sql-cert and --sql-rootcert option definitions had a trailing space instead of a PATH placeholder in both ec_key_base.rb and ec_base.rb, causing the option parser to silently discard the values passed on the CLI.

2. export_from_sql in ec_backup.rb only forwarded sql_host, sql_port, sql_db, sql_user, and sql_password to EcKeyExport. The ssl_cert, sql_key, and sql_rootcert config values were never passed, so the Sequel connection URI was built without any SSL parameters.

3. ec_key_import in ec_restore.rb had the same omission: sql_cert, sql_key, and sql_rootcert were not forwarded to EcKeyImport.

Fix all three issues and add specs to verify SSL config forwarding.

<!--- Provide a short summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail, what problems does it solve? -->

## Related Issue
<!--- If you are suggesting a new feature or change, please create an issue first -->
<!--- Please link to the issue, discourse, or stackoverflow here: -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Chore (non-breaking change that does not add functionality or fix an issue)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] I have read the **CONTRIBUTING** document.
- [ ] I have run the pre-merge tests locally and they pass.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] If `Gemfile.lock` has changed, I have used `--conservative` to do it and included the full output in the Description above.
- [ ] All new and existing tests passed.
- [ ] All commits have been signed-off for [the Developer Certificate of Origin](https://github.com/chef/chef/blob/master/CONTRIBUTING.md#developer-certification-of-origin-dco).
