### PR TITLE
Honor --sql-host, --sql-port and --sql-db for SQL backup/restore (external PostgreSQL)

### DIFF
--- a/lib/chef/knife/ec_base.rb
+++ b/lib/chef/knife/ec_base.rb
@@ -67,13 +67,11 @@ class Chef
 
           option :sql_host,
             :long => '--sql-host HOSTNAME',
-            :description => 'PostgreSQL database hostname (default: localhost)',
-            :default => "localhost"
+            :description => 'PostgreSQL database hostname (default: value from chef-server-running.json, or localhost)'
 
           option :sql_port,
             :long => '--sql-port PORT',
-            :description => 'PostgreSQL database port (default: 5432)',
-            :default => 5432
+            :description => 'PostgreSQL database port (default: value from chef-server-running.json, or 5432)'
 
           option :sql_db,
             :long => '--sql-db DBNAME',

--- a/lib/chef/knife/ec_key_base.rb
+++ b/lib/chef/knife/ec_key_base.rb
@@ -34,13 +34,11 @@ class Chef
 
           option :sql_host,
           :long => '--sql-host HOSTNAME',
-          :description => 'PostgreSQL database hostname (default: localhost)',
-          :default => "localhost"
+          :description => 'PostgreSQL database hostname (default: value from chef-server-running.json, or localhost)'
 
           option :sql_port,
           :long => '--sql-port PORT',
-          :description => 'PostgreSQL database port (default: 5432)',
-          :default => 5432
+          :description => 'PostgreSQL database port (default: value from chef-server-running.json, or 5432)'
 
           option :sql_db,
           :long => '--sql-db DBNAME',
@@ -88,8 +86,9 @@ class Chef
                   require 'sequel'
                   require 'uri'
                   server_uri = URI('postgres://')
-                  server_uri.host = config[:sql_host]
-                  server_uri.port = config[:sql_port]
+                  server_uri.host = config[:sql_host] || 'localhost'
+                  server_uri.port = config[:sql_port] || 5432
+                  server_uri.path = "/#{config[:sql_db]}" if config[:sql_db]
                   server_uri.user = URI.encode_www_form_component(config[:sql_user]) if config[:sql_user]
                   server_uri.password = URI.encode_www_form_component(config[:sql_password]) if config[:sql_password]
                   query_params = []
@@ -123,6 +122,14 @@ class Chef
             config[:sql_user] ||= running_config['private_chef'][hash_key]['sql_user']
             config[:sql_password] ||= (running_config['private_chef'][hash_key]['sql_password'] || sql_password)
             config[:sql_db] ||= 'opscode_chef'
+            # Source the PostgreSQL host/port from the running config so external
+            # PostgreSQL deployments are picked up automatically, the same way the
+            # sql_user/sql_password/sql_db are. ||= ensures an explicit --sql-host /
+            # --sql-port still wins. Embedded installs report a loopback vip, and the
+            # db method falls back to localhost:5432 when these are absent.
+            pg_config = running_config['private_chef']['postgresql'] || {}
+            config[:sql_host] ||= pg_config['vip']
+            config[:sql_port] ||= pg_config['port']
           end
         end
       end

--- a/spec/chef/knife/ec_key_base_spec.rb
+++ b/spec/chef/knife/ec_key_base_spec.rb
@@ -1,6 +1,7 @@
 require File.expand_path(File.join(File.dirname(__FILE__), "..", "..", "spec_helper"))
 require 'chef/knife/ec_key_base'
 require 'chef/automate'
+require 'sequel'
 
 class KeyBaseTester < Chef::Knife
   include Chef::Knife::EcKeyBase
@@ -36,6 +37,56 @@ describe Chef::Knife::EcKeyBase do
       knife.load_config_from_file!
       expect(knife.config[:sql_user]).to eq("cricket")
       expect(knife.config[:sql_password]).to eq("secrete")
+    end
+  end
+
+  # Regression coverage for the external-PostgreSQL bug: the SQL host/port must
+  # be sourced from chef-server-running.json (like sql_user/sql_password/sql_db),
+  # while an explicit --sql-host / --sql-port supplied on the CLI must still win.
+  describe "#load_config_from_file! PostgreSQL host/port autoconfiguration" do
+    let(:external_pg_running_config) {
+      '{"private_chef": { "opscode-erchef": {}, "postgresql": { "vip": "db.external.example.com", "port": 6432, "sql_user": "jiminy", "sql_password": "secret" } } }'
+    }
+
+    before(:each) do
+      allow(Chef::Automate).to receive(:is_installed?).and_return(false)
+      allow(File).to receive(:exist?).and_call_original
+      allow(File).to receive(:exist?).with("/etc/opscode/chef-server-running.json").and_return(true)
+      allow(File).to receive(:read).and_call_original
+      allow(File).to receive(:read).with("/etc/opscode/chef-server-running.json").and_return(external_pg_running_config)
+    end
+
+    it "adopts the PostgreSQL host and port from chef-server-running.json when no CLI flag is given" do
+      knife.load_config_from_file!
+      expect(knife.config[:sql_host]).to eq("db.external.example.com")
+      expect(knife.config[:sql_port]).to eq(6432)
+    end
+
+    it "lets an explicit --sql-host / --sql-port win over the autoconfigured value" do
+      knife.config[:sql_host] = "cli-host.example.com"
+      knife.config[:sql_port] = 2345
+      knife.load_config_from_file!
+      expect(knife.config[:sql_host]).to eq("cli-host.example.com")
+      expect(knife.config[:sql_port]).to eq(2345)
+    end
+  end
+
+  # Regression coverage for #181: the configured database name must be written
+  # into the PostgreSQL connection URI. It was previously resolved but never
+  # applied, so PostgreSQL silently fell back to a database named after the user.
+  describe "#db connection URI" do
+    before(:each) do
+      # Capture the connection string instead of opening a real connection.
+      allow(Sequel).to receive(:connect) { |uri, *| uri }
+    end
+
+    it "includes the configured database name in the connection URI" do
+      knife.config[:sql_db] = "custom_db"
+      expect(knife.db).to include("/custom_db")
+    end
+
+    it "falls back to localhost:5432 when host and port are unset" do
+      expect(knife.db).to start_with("postgres://localhost:5432")
     end
   end
 end


### PR DESCRIPTION
## Problem

`knife ec backup --with-user-sql` does not honor the SQL connection flags
and silently targets the wrong PostgreSQL server **and** database:

- On external-PostgreSQL deployments it always connects to `localhost:5432`
  and fails with `PG::ConnectionBad: Connection refused`.
- The configured database name is ignored, so it connects to a database
  named after the SQL **user** — servers whose DB name differs from the user
  name can't be backed up at all (issue #181).

## Root cause

Both problems live in `EcKeyBase`:

1. **Host/port** — `load_config_from_file!` autoconfigures `sql_user`/
   `sql_password`/`sql_db` from `/etc/opscode/chef-server-running.json` but
   never reads the PostgreSQL **host** or **port**, while `--sql-host`/
   `--sql-port` are declared with hardcoded `localhost`/`5432` defaults that
   always populate the config — so the target can never be derived from the
   running config.
   > Note: this is **not** a `=` vs `||=` issue. `sql_db` already used `||=`,
   > and host/port were never assigned in the autoconfigure block; a `||=`
   > there would have been a no-op against the defaulted option.

2. **Database name** — `#db` builds the connection URI from host, port, user,
   password and query params, but never writes `config[:sql_db]` into the URI
   path, so the resolved database name is dropped and PostgreSQL falls back to
   a user-named database (#181).

## Fix

- Remove the masking `:default => "localhost"`/`5432` from the `--sql-host`/
  `--sql-port` options (`ec_base.rb`, `ec_key_base.rb`).
- Source `sql_host`/`sql_port` from `private_chef.postgresql.vip`/`port` in
  `load_config_from_file!`, using `||=` so an explicit `--sql-host`/
  `--sql-port` still wins.
- Write the database name into the connection URI path in `#db`
  (`server_uri.path = "/#{config[:sql_db]}" if config[:sql_db]`) — the one-line
  fix originally proposed by @ioSpark in #182.
- Fall back to `localhost:5432` in `#db` when host/port are unset, preserving
  embedded-PostgreSQL behavior.

## Backward compatibility

Embedded-PostgreSQL installs report a loopback `vip`, and the `#db` fallback
covers the Automate / no-running-config paths, so those deployments are
unaffected. Explicit CLI flags retain top precedence.

## Tests

Adds specs for: host/port adoption from `chef-server-running.json`, explicit
`--sql-host`/`--sql-port` precedence, and the database name appearing in the
connection URI.

Fixes #181. Refs #182, chef/chef-server#2907.
